### PR TITLE
add modal prop

### DIFF
--- a/components/popup/UIPasswordPrompt/index.js
+++ b/components/popup/UIPasswordPrompt/index.js
@@ -435,7 +435,7 @@ export default class UIPasswordPrompt extends UIController {
         if (!this.isPromptVisible()) {
             return null;
         }
-        if (Platform.OS === 'web') {
+        if (Platform.OS === 'web' || !this.props.modal) {
             return this.renderContainer();
         }
         return (
@@ -452,8 +452,10 @@ export default class UIPasswordPrompt extends UIController {
 
 UIPasswordPrompt.defaultProps = {
     masterPrompt: true,
+    modal: false,
 };
 
 UIPasswordPrompt.propTypes = {
     masterPrompt: PropTypes.bool,
+    modal: PropTypes.bool,
 };


### PR DESCRIPTION
Make UIPasswordProvider non-modal by default (use `modal: true` prop to use Modal)