### PR TITLE
1) New: [UIController] add guardAsync* methods to guard async code ag…

### DIFF
--- a/controllers/UIController/index.js
+++ b/controllers/UIController/index.js
@@ -526,9 +526,9 @@ export default class UIController<Props, State>
     renderSpinnerOverlay() {
         return (<UISpinnerOverlay
             key="SpinnerOverlay"
-            visible={this.state.spinnerVisible}
-            titleContent={this.state.spinnerTitleContent}
-            textContent={this.state.spinnerTextContent}
+            visible={this.state?.spinnerVisible}
+            titleContent={this.state?.spinnerTitleContent || ''}
+            textContent={this.state?.spinnerTextContent || ''}
         />);
     }
 

--- a/controllers/UIController/index.js
+++ b/controllers/UIController/index.js
@@ -68,6 +68,7 @@ export type ControllerState = {
     spinnerTextContent?: string,
     spinnerTitleContent?: string,
     spinnerVisible?: boolean,
+    runningAsyncOperation?: string,
 };
 
 const EmptyInset: ContentInset = Object.freeze({
@@ -484,6 +485,41 @@ export default class UIController<Props, State>
 
     hideIndicator() {
         this.showIndicator(false);
+    }
+
+    // Async Operations
+    getRunningAsyncOperation(): string {
+        return this.state.runningAsyncOperation || '';
+    }
+
+    guardedAsyncRun(operation: () => Promise<void>, name?: string) {
+        (async () => {
+            try {
+                if (this.getRunningAsyncOperation() !== '') {
+                    return;
+                }
+                this.setStateSafely({ runningAsyncOperation: name || 'operation' });
+                try {
+                    await operation();
+                } finally {
+                    this.setStateSafely({ runningAsyncOperation: '' });
+                }
+            } catch (error) {
+                console.log(
+                    `Async operation [${name || ''}] failed: `,
+                    error.message || error,
+                );
+            }
+        })();
+    }
+
+    guardedAsyncNavigation(operation: () => void, name?: string): void {
+        this.guardedAsyncRun(async () => {
+            operation();
+            await new Promise((resolve) => {
+                setTimeout(() => resolve(), 1000);
+            });
+        }, name || 'navigation');
     }
 
     // Render

--- a/controllers/UIModalController/index.js
+++ b/controllers/UIModalController/index.js
@@ -216,7 +216,12 @@ export default class UIModalController
     // Setters
     setContentInset(contentInset: ContentInset, animation: ?AnimationParameters) {
         super.setContentInset(contentInset);
-        const bottomInset = Math.max(0, contentInset.bottom, this.getSafeAreaInsets().bottom);
+        let bottomInset = contentInset.bottom;
+        // If bottom inset is more than zero, then keyboard is visible
+        // so append safe area
+        if (bottomInset > 0) {
+            bottomInset += this.getSafeAreaInsets().bottom;
+        }
         if (animation) {
             Animated.timing(this.marginBottom, {
                 toValue: bottomInset,
@@ -315,7 +320,7 @@ export default class UIModalController
             >
                 <Animated.View
                     style={{
-                        height: contentHeight,
+                        height: contentHeight + this.getSafeAreaInsets().bottom,
                         paddingBottom: this.marginBottom,
                     }}
                 >

--- a/controllers/UIModalController/index.js
+++ b/controllers/UIModalController/index.js
@@ -315,7 +315,7 @@ export default class UIModalController
             >
                 <Animated.View
                     style={{
-                        height: contentHeight + this.getSafeAreaInsets().bottom,
+                        height: contentHeight,
                         paddingBottom: this.marginBottom,
                     }}
                 >


### PR DESCRIPTION
…ainst repeatable running.

2) Fix: [UIModalController] remove safeArea from bottom panel.
3) New: [TONAsync] add guardNavigation to guard navigation methods from repeated invokation.
4) Fix: Trim spaces when address used as a payment recipient.
5) New: [SendGramReceiverScreen] routes to exchange screen in case of selecting own account address.
6) Fix: Prevent repeated taps in account related screens.