### PR TITLE
Extend RN's text input with a noPersonalizedLearning prop

### DIFF
--- a/components/input/UIDetailsInput/index.js
+++ b/components/input/UIDetailsInput/index.js
@@ -342,6 +342,11 @@ export type DetailsProps = ActionProps & {
     ID for InputAccessoryView
     */
     inputAccessoryViewID?: string,
+    /**
+    Set https://developer.android.com/reference/android/widget/TextView#attr_android:imeOptions to flagNoPersonalizedLearning
+    IMPORTANT: not a part of RN yet, we extended TextInput
+    */
+    noPersonalizedLearning?: boolean,
 };
 
 type DetailsState = ActionState & {
@@ -713,6 +718,7 @@ export default class UIDetailsInput<Props, State> extends UIActionComponent<
             theme,
             maxHeight,
             value,
+            noPersonalizedLearning,
         } = this.props;
         const accessibilityLabelProp = accessibilityLabel ? { accessibilityLabel } : null;
         const maxLengthProp = maxLength ? { maxLength } : null;
@@ -769,6 +775,7 @@ export default class UIDetailsInput<Props, State> extends UIActionComponent<
                 inputAccessoryViewID={this.props.inputAccessoryViewID}
                 {...valueProp}
                 {...testIDProp}
+                {...{ noPersonalizedLearning: noPersonalizedLearning || false }}
             />
         );
     }

--- a/components/input/UISeedPhraseInput/index.js
+++ b/components/input/UISeedPhraseInput/index.js
@@ -47,17 +47,22 @@ export default class UISeedPhraseInput extends UIDetailsInput<Props, State> {
         blurOnSubmit: true,
         placeholder: UILocalized.Password,
         autoFocus: false,
-        containerStyle: { },
+        containerStyle: {},
         forceMultiLine: true,
-        keyboardType: 'default', /* Platform.OS === 'android'
+        keyboardType:
+            'default' /* Platform.OS === 'android'
             ? 'visible-password' // to fix Android bug with keyboard suggestions
-            : 'default', */ // CRAP, we can't use the hack as it breaks the multiline support :(
+            : 'default', */, // CRAP, we can't use the hack as it breaks the multiline support :(
         phraseToCheck: '',
         commentTestID: 'comment',
         onChangeIsValidPhrase: () => {},
         onBlur: () => {},
         totalWords: 12, // default value
         words: [],
+        // Set an InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS flag to a keyboard on Android. Needed by security reasons
+        autoCorrect: false,
+        autoComplete: 'off',
+        noPersonalizedLearning: true,
     };
 
     static splitPhrase(phrase: string): Array<string> {


### PR DESCRIPTION
Could prevent seed phrase leaking