### PR TITLE
chat input - "auto grow" behavior

### DIFF
--- a/components/chat/UIChatInput/index.js
+++ b/components/chat/UIChatInput/index.js
@@ -121,6 +121,13 @@ export default class UIChatInput extends UIDetailsInput<Props, State> {
     }
 
     // Events
+    onMobileChange(event: any) {
+        // Seems that it is not necessary anymore to handle the auto-growing behavior
+        // on Android. So, I'm not removing the method from the UIDetailsInput class
+        // and instead overriding it in here to avoid introduce any possible unexpected
+        // behavior.
+    }
+
     onLayout = (e: any) => {
         const { nativeEvent } = e;
         // If the browser window is resized, this forces the input

--- a/components/input/UIPinCodeInput/index.js
+++ b/components/input/UIPinCodeInput/index.js
@@ -123,20 +123,23 @@ export default class UIPinCodeInput extends UIComponent<Props, State> {
 
     addKeyboardListener() {
         if (Platform.OS === 'web') {
-            document.addEventListener('keypress', this.onWebKeyPressed);
+            // Use of 'keydown' event to support backspace key.
+            document.addEventListener('keydown', this.onWebKeyPressed);
         }
     }
 
     removeKeyboardListener() {
         if (Platform.OS === 'web') {
-            document.removeEventListener('keypress', this.onWebKeyPressed);
+            document.removeEventListener('keydown', this.onWebKeyPressed);
         }
     }
 
     // events
     onWebKeyPressed = (pressedKey: any) => {
-        if (pressedKey.charCode > 47 && pressedKey.charCode < 58) {
+        if (pressedKey.keyCode > 47 && pressedKey.keyCode < 58) {
             this.onKeyPress(`${pressedKey.key}`);
+        } else if (pressedKey.keyCode === 8) {
+            this.onDeletePress();
         }
     };
 


### PR DESCRIPTION
Override method to avoid handling the "auto grow" behavior for the chat text input.
Use of 'keydown' event on UIPinCodeInput to support backspace key.