### PR TITLE
Use RNGH ScrollView inside dialog controller

### DIFF
--- a/controllers/UIDialogController/index.js
+++ b/controllers/UIDialogController/index.js
@@ -1,13 +1,13 @@
 /* eslint-disable class-methods-use-this */
 import React from 'react';
 import {
-    ScrollView,
     View,
     Text,
     StyleSheet,
     Animated,
     LayoutAnimation,
 } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 
 import UIController from '../UIController';
 import UIColor from '../../helpers/UIColor';


### PR DESCRIPTION
Looks like in current version of RN and RNGH ScrollView couldn't work properly on Android, using the one from RNGH solve this problem.