### PR TITLE
remove unneeded deploy business logic from UIKit part

### DIFF
--- a/components/chat/cells/UIChatTransactionCell.js
+++ b/components/chat/cells/UIChatTransactionCell.js
@@ -188,8 +188,6 @@ export default class UIChatTransactionCell extends UIPureComponent<Props, State>
             const trx = this.getTransaction();
             if (trx.aborted) {
                 return styles.cardAborted;
-            } else if (trx.deploy) {
-                return styles.cardInvite; // deploy looks the same as invite now
             }
             return styles.cardSpending;
         } else if (type === TypeOfTransaction.Bill) {


### PR DESCRIPTION
No need to add any extra business logic to UIKit.
In case we want to display the bubble as `blue` just set the proper transaction type from the external code. No additional logic should be written here.