### PR TITLE
Use native driver for IconAnimation

### DIFF
--- a/components/buttons/UIButton/IconAnimation.js
+++ b/components/buttons/UIButton/IconAnimation.js
@@ -70,6 +70,7 @@ export default class IconAnimation extends UIComponent<Props, State> {
                 this.props.animation === IconAnimation.Animation.Forward
                     ? Easing.ease
                     : Easing.linear,
+            useNativeDriver: true,
         });
     }
 


### PR DESCRIPTION
IconAnimation uses `transform` to apply animations, so it's safe to use `useNativeDriver` that significantly increase performance on mobile devices.