### PR TITLE
add right inline element to the material text view

### DIFF
--- a/packages/hydrogen/src/UIMaterialTextView.tsx
+++ b/packages/hydrogen/src/UIMaterialTextView.tsx
@@ -20,7 +20,7 @@ export type UIMaterialTextViewCommonProps = UITextViewProps & {
     error?: boolean;
     success?: boolean;
     onLayout?: Pick<UITextViewProps, 'onLayout'>;
-    inlineElementRight?: React.ReactNode;
+    right?: React.ReactNode;
 };
 
 const getBorderColor = (
@@ -451,7 +451,7 @@ const UIMaterialTextViewFloating = React.forwardRef<
     props: UIMaterialTextViewCommonProps,
     ref,
 ) {
-    const { label, onChangeText, onLayout, inlineElementRight, ...rest } = props;
+    const { label, onChangeText, onLayout, right, ...rest } = props;
     const theme = useTheme();
     const {
         inputHasValue,
@@ -511,9 +511,9 @@ const UIMaterialTextViewFloating = React.forwardRef<
                         </Animated.Text>
                     </Animated.View>
                     {
-                        inlineElementRight ? (
+                        right ? (
                             <View>
-                                {inlineElementRight}
+                                {right}
                             </View>
                         ) : null
                     }
@@ -530,7 +530,7 @@ const UIMaterialTextViewSimple = React.forwardRef<
     props: UIMaterialTextViewCommonProps,
     ref,
 ) {
-    const { label, onChangeText, onLayout, inlineElementRight, ...rest } = props;
+    const { label, onChangeText, onLayout, right, ...rest } = props;
     const { onChangeText: onChangeTextProp } = useUITextViewValue(
         ref,
         false,
@@ -551,9 +551,9 @@ const UIMaterialTextViewSimple = React.forwardRef<
                         onChangeText={onChangeTextProp}
                     />
                     {
-                        inlineElementRight ? (
+                        right ? (
                             <View>
-                                {inlineElementRight}
+                                {right}
                             </View>
                         ) : null
                     }


### PR DESCRIPTION
There are a few moments to discuss:

- Bug with layout after updated value receive
<img width="434" alt="Снимок экрана 2021-03-03 в 15 06 14" src="https://user-images.githubusercontent.com/22961641/109773630-03ddab00-7c32-11eb-8fd4-aeaf314a2793.png">

- Should UIMaterialTextView support the next previously available props:
> hideBottomLine
> forceMultiLine
> maxLines
> onHeightChange
> etc

- Should we add a specific view for the non editable state (always hide bottom line, allow few lines, change text color)

