### PR TITLE
Pass url press handler to all messages that use it

### DIFF
--- a/Example/src/screens/Browser.tsx
+++ b/Example/src/screens/Browser.tsx
@@ -87,9 +87,13 @@ const BrowserScreen = React.forwardRef<BrowserScreenRef>((_props, ref) => {
         },
     }));
 
+    const onPressUrl = React.useCallback(() => {
+        console.log('url handled');
+    }, []);
+
     return (
         <>
-            <UIBrowser messages={messages} />
+            <UIBrowser messages={messages} onPressUrl={onPressUrl} />
             <SafeAreaInsetsContext.Consumer>
                 {(insets) => (
                     <UIBottomSheet
@@ -118,7 +122,7 @@ const BrowserScreen = React.forwardRef<BrowserScreenRef>((_props, ref) => {
                                     key: `${Date.now()}-address-input`,
                                     status: MessageStatus.Received,
                                     type: InteractiveMessageType.AddressInput,
-                                    prompt: 'What wallet do you want to work with?',
+                                    prompt: 'What wallet do you want to work with? example url: https://google.com',
                                     mainAddress: '0:000',
                                     input: {
                                         validateAddress: (text: string) => {
@@ -389,6 +393,7 @@ const BrowserScreen = React.forwardRef<BrowserScreenRef>((_props, ref) => {
                                     type: InteractiveMessageType.EncryptionBox,
                                     encryptionBoxes,
                                     onAddEncryptionBox: (
+                                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
                                         _privateKey: string,
                                     ) => {
                                         const newEncryptionBox = {

--- a/Example/src/screens/Chat.tsx
+++ b/Example/src/screens/Chat.tsx
@@ -309,6 +309,9 @@ const ChatStack = createStackNavigator();
 const ChatWindowScreen = () => {
     const [messages, setMessages] = React.useState(initialMessages);
     const onLoadEarlierMessages = React.useCallback(() => undefined, []);
+    const onPressUrl = React.useCallback(() => {
+        console.log('url handled');
+    }, []);
     const onSendMedia = React.useCallback(() => undefined, []);
     const onSendDocument = React.useCallback(() => undefined, []);
     const onItemSelected = React.useCallback(
@@ -338,6 +341,7 @@ const ChatWindowScreen = () => {
             <UIChatList
                 nativeID="chatSectionList"
                 onLoadEarlierMessages={onLoadEarlierMessages}
+                onPressUrl={onPressUrl}
                 canLoadMore
                 isLoadingMore={false}
                 messages={messages}

--- a/packages/browser/src/UIBrowser.tsx
+++ b/packages/browser/src/UIBrowser.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 
 import { PortalManager } from '@tonlabs/uikit.hydrogen';
+import type { OnPressUrl } from '@tonlabs/uikit.chats';
 
 import { UIBrowserList } from './UIBrowserList';
 import type { BrowserMessage } from './types';
 
 type UIBrowserProps = {
     messages: BrowserMessage[];
+    onPressUrl?: OnPressUrl;
 };
 
-export function UIBrowser({ messages }: UIBrowserProps) {
+export function UIBrowser({ messages, onPressUrl }: UIBrowserProps) {
     return (
         <PortalManager id="browser" renderOnlyLastPortal>
-            <UIBrowserList messages={messages} />
+            <UIBrowserList messages={messages} onPressUrl={onPressUrl} />
         </PortalManager>
     );
 }

--- a/packages/browser/src/UIBrowserList.tsx
+++ b/packages/browser/src/UIBrowserList.tsx
@@ -7,6 +7,8 @@ import {
     ChatMessageType,
     CommonChatListProps,
     UICommonChatList,
+    OnPressUrl,
+    UrlPressHandlerContext,
 } from '@tonlabs/uikit.chats';
 import { BrowserMessage, InteractiveMessageType } from './types';
 import { getFormattedList } from './getFormattedList';
@@ -22,6 +24,7 @@ import { EncryptionBox } from './Inputs/EncryptionBox';
 
 type UIBrowserListProps = {
     messages: BrowserMessage[];
+    onPressUrl?: OnPressUrl;
     bottomInset?: number;
 };
 
@@ -83,33 +86,38 @@ const renderBubble = () => (
         return <TransactionConfirmation {...item} onLayout={onLayout} />;
     }
     if (item.type === InteractiveMessageType.QRCode) {
-        return <QRCode {...item} onLayout={onLayout} />
+        return <QRCode {...item} onLayout={onLayout} />;
     }
 
     return null;
 };
 
 export const UIBrowserList = React.forwardRef<FlatList, UIBrowserListProps>(
-    function UIBrowserListForwarded({ messages }: UIBrowserListProps, ref) {
+    function UIBrowserListForwarded(
+        { messages, onPressUrl }: UIBrowserListProps,
+        ref,
+    ) {
         const formattedMessages = React.useMemo(
             () => getFormattedList(messages),
             [messages],
         );
         return (
-            <UICommonChatList
-                forwardRef={ref}
-                nativeID="browserList"
-                renderBubble={renderBubble()}
-                getItemLayoutFabric={flatListGetItemLayoutFabric}
-            >
-                {(chatListProps: CommonChatListProps<BrowserMessage>) => (
-                    <FlatList
-                        testID="browser_container"
-                        data={formattedMessages}
-                        {...chatListProps}
-                    />
-                )}
-            </UICommonChatList>
+            <UrlPressHandlerContext.Provider value={onPressUrl}>
+                <UICommonChatList
+                    forwardRef={ref}
+                    nativeID="browserList"
+                    renderBubble={renderBubble()}
+                    getItemLayoutFabric={flatListGetItemLayoutFabric}
+                >
+                    {(chatListProps: CommonChatListProps<BrowserMessage>) => (
+                        <FlatList
+                            testID="browser_container"
+                            data={formattedMessages}
+                            {...chatListProps}
+                        />
+                    )}
+                </UICommonChatList>
+            </UrlPressHandlerContext.Provider>
         );
     },
 );

--- a/packages/chats/src/BubblePlainText.tsx
+++ b/packages/chats/src/BubblePlainText.tsx
@@ -20,7 +20,7 @@ import {
     useTheme,
 } from '@tonlabs/uikit.hydrogen';
 
-import { MessageStatus } from './types';
+import { MessageStatus, OnPressUrl } from './types';
 import type { ChatPlainTextMessage, PlainTextMessage } from './types';
 import {
     useBubblePosition,
@@ -40,6 +40,14 @@ const useUrlStyle = (status: MessageStatus) => {
 
     return [{ color: theme[ColorVariants.StaticTextPrimaryLight] }, styles.urlSent];
 };
+
+export const UrlPressHandlerContext = React.createContext<OnPressUrl>(
+    undefined,
+);
+
+function useUrlPressHandler() {
+    return React.useContext(UrlPressHandlerContext);
+}
 
 const getFontColor = (message: PlainTextMessage) => {
     if (message.status === MessageStatus.Aborted) {
@@ -237,6 +245,8 @@ export function BubbleChatPlainText(props: ChatPlainTextMessage) {
         [props.time],
     );
 
+    const urlPressHandler = useUrlPressHandler();
+
     return (
         <PlainTextContainer {...props}>
             <UILabel
@@ -250,9 +260,7 @@ export function BubbleChatPlainText(props: ChatPlainTextMessage) {
                         {
                             type: 'url',
                             style: urlStyle,
-                            onPress: (url: string, index: number) =>
-                                props.onPressUrl &&
-                                props.onPressUrl(url, index),
+                            onPress: urlPressHandler,
                         },
                     ]}
                 >
@@ -286,6 +294,7 @@ export function BubbleChatPlainText(props: ChatPlainTextMessage) {
 
 export function BubbleSimplePlainText(props: PlainTextMessage) {
     const urlStyle = useUrlStyle(props.status);
+    const urlPressHandler = useUrlPressHandler();
 
     return (
         <PlainTextContainer {...props}>
@@ -300,9 +309,7 @@ export function BubbleSimplePlainText(props: PlainTextMessage) {
                         {
                             type: 'url',
                             style: urlStyle,
-                            onPress: (url: string, index: number) =>
-                                props.onPressUrl &&
-                                props.onPressUrl(url, index),
+                            onPress: urlPressHandler,
                         },
                     ]}
                 >

--- a/packages/chats/src/UIChatList.tsx
+++ b/packages/chats/src/UIChatList.tsx
@@ -6,9 +6,9 @@ import { SectionExtra, UIChatListFormatter } from './UIChatListFormatter';
 import { UILoadMoreButton } from './UILoadMoreButton';
 import { UICommonChatList } from './UICommonChatList';
 import { DateSeparator } from './DateSeparator';
-import { ChatMessage, ChatMessageType } from './types';
+import { ChatMessage, ChatMessageType, OnPressUrl } from './types';
 import { sectionListGetItemLayout } from './UIChatListLayout';
-import { BubbleChatPlainText } from './BubblePlainText';
+import { BubbleChatPlainText, UrlPressHandlerContext } from './BubblePlainText';
 import { BubbleSystem } from './BubbleSystem';
 import { BubbleTransaction } from './BubbleTransaction';
 import { BubbleImage } from './BubbleImage';
@@ -88,6 +88,7 @@ type UIChatListProps = {
     canLoadMore: boolean;
     isLoadingMore: boolean;
     onLoadEarlierMessages: () => void;
+    onPressUrl?: OnPressUrl;
     bottomInset?: number;
 };
 
@@ -99,6 +100,7 @@ export const UIChatList = React.forwardRef<SectionList, UIChatListProps>(
             canLoadMore,
             isLoadingMore,
             onLoadEarlierMessages,
+            onPressUrl,
         }: UIChatListProps,
         ref,
     ) {
@@ -121,27 +123,29 @@ export const UIChatList = React.forwardRef<SectionList, UIChatListProps>(
         );
 
         return (
-            <UICommonChatList
-                forwardRef={ref}
-                nativeID={nativeID}
-                renderBubble={renderBubble}
-                getItemLayoutFabric={sectionListGetItemLayout}
-                canLoadMore={canLoadMore}
-            >
-                {(chatListProps) => (
-                    <SectionList
-                        testID="chat_container"
-                        sections={sections}
-                        // Because the List is inverted in order to render from the bottom,
-                        // the title (date) for each section becomes the footer instead of header.
-                        renderSectionFooter={renderSectionTitle}
-                        // renderSectionHeader={section => this.renderSectionStatus(section)}
-                        onEndReached={onLoadEarlierMessages}
-                        ListFooterComponent={renderLoadMore}
-                        {...chatListProps}
-                    />
-                )}
-            </UICommonChatList>
+            <UrlPressHandlerContext.Provider value={onPressUrl}>
+                <UICommonChatList
+                    forwardRef={ref}
+                    nativeID={nativeID}
+                    renderBubble={renderBubble}
+                    getItemLayoutFabric={sectionListGetItemLayout}
+                    canLoadMore={canLoadMore}
+                >
+                    {(chatListProps) => (
+                        <SectionList
+                            testID="chat_container"
+                            sections={sections}
+                            // Because the List is inverted in order to render from the bottom,
+                            // the title (date) for each section becomes the footer instead of header.
+                            renderSectionFooter={renderSectionTitle}
+                            // renderSectionHeader={section => this.renderSectionStatus(section)}
+                            onEndReached={onLoadEarlierMessages}
+                            ListFooterComponent={renderLoadMore}
+                            {...chatListProps}
+                        />
+                    )}
+                </UICommonChatList>
+            </UrlPressHandlerContext.Provider>
         );
     },
 );

--- a/packages/chats/src/index.ts
+++ b/packages/chats/src/index.ts
@@ -5,7 +5,10 @@ export * from './UIChatInput/ChatInputContainer';
 export * from './UIChatInput/useChatInputValue';
 export * from './UIChatInput/useChatMaxLengthAlert';
 
-export { BubbleSimplePlainText } from './BubblePlainText';
+export {
+    BubbleSimplePlainText,
+    UrlPressHandlerContext,
+} from './BubblePlainText';
 export { BubbleActionButton } from './BubbleActionButton';
 
 export * from './types';

--- a/packages/chats/src/types.ts
+++ b/packages/chats/src/types.ts
@@ -39,13 +39,14 @@ export enum ChatMessageType {
     Sticker = 'stk',
     ActionButton = 'act',
 }
-
+export type OnPressUrl =
+    | ((url: string, index?: number) => void | Promise<void>)
+    | undefined;
 export type PlainTextMessage = BubbleBaseT & {
     type: ChatMessageType.PlainText;
     text: string;
     actionText?: string;
     onTouchText?: () => void | Promise<void>;
-    onPressUrl?: (url: string, index?: number) => void | Promise<void>;
 };
 
 export type ActionButtonMessage = BubbleBaseT & {


### PR DESCRIPTION
I've decided that it's better to have a single handler for all links, that is passed through context, as it seemed to me that with props is easy to forget to pass it, and looks like it has a single logic in it for all links