### PR TITLE
Experiment with animated theme switching

### DIFF
--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -375,8 +375,8 @@ const AppWrapper = () => {
                     isDarkTheme,
                     toggleTheme: () => {
                         setIsDarkTheme(!isDarkTheme);
-                        setIsHidden(true);
-                        setImmediate(() => setIsHidden(false));
+                        // setIsHidden(true);
+                        // setImmediate(() => setIsHidden(false));
                     },
                 }}
             >

--- a/packages/hydrogen/src/UIBackgroundView.tsx
+++ b/packages/hydrogen/src/UIBackgroundView.tsx
@@ -1,22 +1,30 @@
 import * as React from 'react';
 import { ViewStyle, View, ColorValue } from 'react-native';
 import type { StyleProp, ViewProps } from 'react-native';
+import Animated, {
+    interpolateColor,
+    useAnimatedStyle,
+    useSharedValue,
+    withTiming,
+} from 'react-native-reanimated';
 
 import { ColorVariants, useTheme } from './Colors';
 
 type Props = Omit<ViewProps, 'style'> & {
-    color?: ColorVariants,
+    color?: ColorVariants;
     style?: StyleProp<ViewStyle>;
-    children?: React.ReactNode,
+    children?: React.ReactNode;
 };
 
-export const UIBackgroundView = React.forwardRef<View, Props>(
+export const UIBackgroundView2 = React.forwardRef<View, Props>(
     function UIBackgroundViewForwarded(
         {
             color: colorProp = ColorVariants.BackgroundPrimary,
             style,
             ...rest
-        }: Props, ref) {
+        }: Props,
+        ref,
+    ) {
         const theme = useTheme();
         const colorStyle: { backgroundColor: ColorValue } = React.useMemo(
             () => ({
@@ -24,15 +32,46 @@ export const UIBackgroundView = React.forwardRef<View, Props>(
             }),
             [theme, colorProp],
         );
+        return <View ref={ref} {...rest} style={[style, colorStyle]} />;
+    },
+);
+
+export const UIBackgroundView = React.forwardRef<View, Props>(
+    function UIBackgroundView2Forwarded(
+        {
+            color: colorProp = ColorVariants.BackgroundPrimary,
+            style,
+            ...rest
+        }: Props,
+        ref,
+    ) {
+        const theme = useTheme();
+
+        const previousColor = useSharedValue(theme[colorProp] as string);
+        const currentColor = useSharedValue(theme[colorProp] as string);
+        const transitionProgress = useSharedValue(1);
+
+        React.useEffect(() => {
+            if (transitionProgress.value !== 0) {
+                previousColor.value = currentColor.value;
+                currentColor.value = theme[colorProp] as string;
+                transitionProgress.value = 0;
+                transitionProgress.value = withTiming(1, { duration: 100 });
+            }
+        }, [colorProp, theme, previousColor, currentColor, transitionProgress]);
+
+        const colorStyle = useAnimatedStyle(() => {
+            return {
+                backgroundColor: interpolateColor(
+                    transitionProgress.value,
+                    [0, 1],
+                    [previousColor.value, currentColor.value],
+                ),
+            };
+        });
         return (
-            <View
-                ref={ref}
-                {...rest}
-                style={[
-                    style,
-                    colorStyle,
-                ]}
-            />
+            // @ts-ignore
+            <Animated.View ref={ref} {...rest} style={[style, colorStyle]} />
         );
     },
 );


### PR DESCRIPTION
IMPORTANT: 
This is just an experiment and the PR is a place to share thoughts.

MOTIVATION:
I saw on a web site an animation of transition between light and dark theme colors for a View and instantly I thought that it would be cool for us to implement the same thing, besides nothing can stop us from doing that!



So in this PR, I've tried to apply it to UIBackgroundView, and... it doesn't work very well actually, because we have a lot of other things, that don't change their color with animations and do it instantly instead.

But, instead we can create a hook, that does the same thing, but can be applied to whatever component needed, and we can even apply it some of our basic components like UILabel and UIButton, hence cover most of transitions.

I have high believes that [upcoming change in reanimated@2.3.0](https://github.com/software-mansion/react-native-reanimated/commit/0c2f66f9855a26efe24f52ecff927fe847f7a80e) will even help to do it in performant way, when we actually will reuse the styles across al components.

PS. Also it worth to play with [`LayoutAnimations`](https://github.com/software-mansion/react-native-reanimated/blob/master/docs/versioned_docs/version-2.3.0-alpha.1/layout_animations.md), maybe it can be easily solved with it.