### PR TITLE
Use JSIExecutorInitializer to inject haptic functions

### DIFF
--- a/Example/ios/Podfile
+++ b/Example/ios/Podfile
@@ -8,7 +8,7 @@ target 'Quiver UI' do
   use_react_native!(
     :path => "../../node_modules/react-native",
     # to enable hermes on iOS, change `false` to `true` and then install pods
-    :hermes_enabled => false
+    :hermes_enabled => true
   )
 
   permissions_path = '../../node_modules/react-native-permissions/ios'
@@ -29,6 +29,11 @@ target 'Quiver UI' do
   use_flipper!()
   post_install do |installer|
     react_native_post_install(installer)
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['OTHER_CPLUSPLUSFLAGS'] = '-DDONT_AUTOINSTALL_REANIMATED'
+      end
+    end
   end
 end
 

--- a/Example/ios/Quiver UI.xcodeproj/project.pbxproj
+++ b/Example/ios/Quiver UI.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* ReactNavigationSurfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* ReactNavigationSurfTests.m */; };
 		137F8A98A77769BBB45BB98F /* libPods-Quiver UI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6514A8C6CC5A82913914A6D6 /* libPods-Quiver UI.a */; };
-		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		1C35FC4EE0A072D56C0D2B43 /* libPods-Quiver UI-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 920B7E7862E0BC2B9C24DE6A /* libPods-Quiver UI-tvOSTests.a */; };
-		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
+		2D02E4BC1E0B4A80006451C7 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* ReactNavigationSurfTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* ReactNavigationSurfTests.m */; };
 		A60D4178253DCC370046B610 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A60D4177253DCC370046B610 /* Images.xcassets */; };
@@ -53,7 +53,7 @@
 		0D289A5D8B1E5788B9D470EA /* Pods-Quiver UI-tvOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Quiver UI-tvOSTests.release.xcconfig"; path = "Target Support Files/Pods-Quiver UI-tvOSTests/Pods-Quiver UI-tvOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Quiver UI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Quiver UI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -142,7 +142,7 @@
 			children = (
 				A60D4177253DCC370046B610 /* Images.xcassets */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
-				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
@@ -464,10 +464,12 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Quiver UI-Quiver UITests/Pods-Quiver UI-Quiver UITests-frameworks.sh",
+				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -496,10 +498,12 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Quiver UI/Pods-Quiver UI-frameworks.sh",
+				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -644,7 +648,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -654,7 +658,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */,
-				2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */,
+				2D02E4BC1E0B4A80006451C7 /* AppDelegate.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -741,6 +745,7 @@
 			baseConfigurationReference = C37FD4F69612A9731C064BBD /* Pods-Quiver UI.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = S87M7476F9;
@@ -771,6 +776,7 @@
 			baseConfigurationReference = B7083FA2B9E71BE3A4E39210 /* Pods-Quiver UI.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = S87M7476F9;
@@ -932,7 +938,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -993,7 +999,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 i386";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Example/ios/Quiver UI/AppDelegate.mm
+++ b/Example/ios/Quiver UI/AppDelegate.mm
@@ -3,6 +3,25 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTBridgeDelegate.h>
+
+#if __has_include(<reacthermes/HermesExecutorFactory.h>)
+#import <reacthermes/HermesExecutorFactory.h>
+typedef HermesExecutorFactory ExecutorFactory;
+#elif __has_include(<React/HermesExecutorFactory.h>)
+#import <React/HermesExecutorFactory.h>
+typedef facebook::react::HermesExecutorFactory ExecutorFactory;
+#else
+#import <React/JSCExecutorFactory.h>
+typedef JSCExecutorFactory ExecutorFactory;
+#endif
+
+#if __has_include(<React/RCTJSIExecutorRuntimeInstaller.h>)
+#import <React/RCTJSIExecutorRuntimeInstaller.h>
+#endif
+
+#import <RNReanimated/REAInitializer.h>
+#import <UIKitHydrogen/HHapticJSIExecutorInitializer.h>
 
 #if DEBUG
 #import <FlipperKit/FlipperClient.h>
@@ -22,6 +41,10 @@ static void InitializeFlipper(UIApplication *application) {
   [client start];
 }
 #endif
+
+@interface AppDelegate () <RCTCxxBridgeDelegate>
+
+@end
 
 @implementation AppDelegate
 
@@ -57,6 +80,18 @@ static void InitializeFlipper(UIApplication *application) {
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge {
+  const auto withHHapticInstaller = tonlabs::uikit::HHapticJSIExecutorRuntimeInstaller(bridge, NULL);
+  const auto withReanimatedInstaller = reanimated::REAJSIExecutorRuntimeInstaller(bridge, withHHapticInstaller);
+  
+  #if __has_include(<React/RCTJSIExecutorRuntimeInstaller.h>)
+    // installs globals such as console, nativePerformanceNow, etc.
+    return std::make_unique<ExecutorFactory>(RCTJSIExecutorRuntimeInstaller(withReanimatedInstaller));
+  #else
+    return std::make_unique<ExecutorFactory>(withReanimatedInstaller);
+  #endif
 }
 
 @end

--- a/Example/package.json
+++ b/Example/package.json
@@ -73,7 +73,7 @@
     "react-native-parsed-text": "git+https://github.com/FactorBench/react-native-parsed-text.git",
     "react-native-permissions": "3.0.0",
     "react-native-qrcode-scanner": "1.5.4",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area": "^0.5.1",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-screens": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "react-native-gesture-handler": "^1.10.3",
         "react-native-image-picker": "*",
         "react-native-navigation-bar-color": "^2.0.1",
-        "react-native-reanimated": "^2.2.0",
+        "react-native-reanimated": "2.3.0-alpha.2",
         "react-native-safe-area": "^0.5.1",
         "react-native-safe-area-context": "^3.1.3",
         "react-native-screens": "^3.3.0",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -48,7 +48,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-redash": "^16.0.11",
     "react-native-svg": "^12.1.1",
     "typescript": "^4.0.3"
@@ -58,7 +58,7 @@
     "react-dom": "^16.13.1",
     "react-native": "^0.63.0",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-redash": "^16.0.11",
     "react-native-svg": "^12.1.1"
   },

--- a/packages/chats/package.json
+++ b/packages/chats/package.json
@@ -60,7 +60,7 @@
     "react-native": "0.64.2",
     "react-native-document-picker": "3.2.4",
     "react-native-image-picker": "git+https://github.com/FactorBench/react-native-image-picker.git#develop",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-svg": "12.1.0",
     "rn-fetch-blob": "git+https://github.com/FactorBench/rn-fetch-blob.git#239d8ab1d26334f98f5dc1b4fac32b7c55cf8d39",
@@ -73,7 +73,7 @@
     "react-native-document-picker": "^3.2.4",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-image-picker": "*",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-svg": "^12.1.0",
     "rn-fetch-blob": "git+https://github.com/FactorBench/rn-fetch-blob.git#239d8ab1d26334f98f5dc1b4fac32b7c55cf8d39"

--- a/packages/flask/package.json
+++ b/packages/flask/package.json
@@ -51,7 +51,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-svg": "^12.1.1",
     "react-native-view-shot": "^3.1.2",
     "@types/qrcode": "^1.4.0",
@@ -62,7 +62,7 @@
     "react-dom": "^17.0.1",
     "react-native": "^0.64.2",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-svg": "^12.1.1",
     "react-native-view-shot": "^3.1.2"
   },

--- a/packages/hydrogen/ios/HHapticJSIExecutorInitializer.h
+++ b/packages/hydrogen/ios/HHapticJSIExecutorInitializer.h
@@ -1,0 +1,25 @@
+//
+//  HHapticJSIExecutorInitializer.h
+//  uikit.hydrogen
+//
+//  Created by Aleksei Saveliev on 20.08.2021.
+//
+
+#import <React/RCTBridge+Private.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+#import <jsireact/JSIExecutor.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace tonlabs {
+namespace uikit {
+  using namespace facebook::react;
+
+  JSIExecutor::RuntimeInstaller HHapticJSIExecutorRuntimeInstaller(
+      RCTBridge *bridge,
+      JSIExecutor::RuntimeInstaller runtimeInstallerToWrap);
+
+} // namespace uikit
+} // namespace tonlabs
+
+NS_ASSUME_NONNULL_END

--- a/packages/hydrogen/ios/HHapticJSIExecutorInitializer.mm
+++ b/packages/hydrogen/ios/HHapticJSIExecutorInitializer.mm
@@ -1,0 +1,107 @@
+//
+//  HHapticJSIExecutorInitializer.m
+//  uikit.hydrogen
+//
+//  Created by Aleksei Saveliev on 20.08.2021.
+//
+
+#import "HHapticJSIExecutorInitializer.h"
+#import "HHapticModule.h"
+
+#import <RNReanimated/NativeReanimatedModule.h>
+
+namespace tonlabs {
+namespace uikit {
+using namespace facebook::react;
+
+JSIExecutor::RuntimeInstaller HHapticJSIExecutorRuntimeInstaller(
+                                                             RCTBridge *bridge,
+                                                             JSIExecutor::RuntimeInstaller runtimeInstallerToWrap) {
+    const auto runtimeInstaller = [bridge, runtimeInstallerToWrap](facebook::jsi::Runtime &runtime)
+    {
+        if (!bridge)
+        {
+            return;
+        }
+        
+        auto jsCallInvoker = bridge.jsCallInvoker;
+        
+        HHapticModule *hapticModule = [bridge moduleForName:@"HHapticModule"];
+        
+        jsi::Object reanimatedModuleProxy = runtime.global().getPropertyAsObject(runtime, "__reanimatedModuleProxy");
+        std::shared_ptr<reanimated::NativeReanimatedModule> reanimatedModule = std::static_pointer_cast<reanimated::NativeReanimatedModule>(reanimatedModuleProxy.getHostObject(runtime));
+        
+        jsi::Runtime &reanimatedUIRuntime = *reanimatedModule->runtime.get();
+        
+        
+        auto hapticImpactCallback = [hapticModule](
+                                            jsi::Runtime& rt,
+                                            const jsi::Value& thisVal,
+                                            const jsi::Value *args,
+                                            size_t count
+                                            ) -> jsi::Value {
+            const auto inputStyle = args[0].asString(rt);
+            
+            [hapticModule hapticImpact:[NSString stringWithUTF8String:inputStyle.utf8(rt).c_str()]];
+            
+            return jsi::Value::undefined();
+        };
+        
+        jsi::Value hapticImpact = jsi::Function::createFromHostFunction(
+                                                                        reanimatedUIRuntime,
+                                                                        jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticImpact"),
+                                                                        1,
+                                                                        hapticImpactCallback);
+        
+        reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticImpact", hapticImpact);
+        
+        auto hapticSelectionCallback = [hapticModule](
+                                               jsi::Runtime& rt,
+                                               const jsi::Value& thisVal,
+                                               const jsi::Value *args,
+                                               size_t count
+                                               ) -> jsi::Value {
+            [hapticModule hapticSelection];
+            
+            return jsi::Value::undefined();
+        };
+        
+        jsi::Value hapticSelection = jsi::Function::createFromHostFunction(
+                                                                           reanimatedUIRuntime,
+                                                                           jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticSelection"),
+                                                                           0,
+                                                                           hapticSelectionCallback);
+        
+        reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticSelection", hapticSelection);
+        
+        auto hapticNotificationCallback = [hapticModule](
+                                                  jsi::Runtime& rt,
+                                                  const jsi::Value& thisVal,
+                                                  const jsi::Value *args,
+                                                  size_t count
+                                                  ) -> jsi::Value {
+            const auto inputType = args[0].asString(rt);
+            
+            [hapticModule hapticNotification:[NSString stringWithUTF8String:inputType.utf8(rt).c_str()]];
+            
+            return jsi::Value::undefined();
+        };
+        
+        jsi::Value hapticNotification = jsi::Function::createFromHostFunction(
+                                                                              reanimatedUIRuntime,
+                                                                              jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticNotification"),
+                                                                              1,
+                                                                              hapticNotificationCallback);
+        
+        reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticNotification", hapticNotification);
+        
+        if (runtimeInstallerToWrap)
+        {
+            runtimeInstallerToWrap(runtime);
+        }
+    };
+    return runtimeInstaller;
+}
+
+} // namespace uikit
+} // namespace tonlabs

--- a/packages/hydrogen/ios/HHapticModule.h
+++ b/packages/hydrogen/ios/HHapticModule.h
@@ -10,4 +10,8 @@
 
 @interface HHapticModule : NSObject<RCTBridgeModule>
 
+- (void)hapticImpact:(NSString *)inputStyle;
+- (void)hapticSelection;
+- (void)hapticNotification:(NSString *)inputType;
+
 @end

--- a/packages/hydrogen/ios/HHapticModule.mm
+++ b/packages/hydrogen/ios/HHapticModule.mm
@@ -11,12 +11,6 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-#import <React/RCTBridge+Private.h>
-#import <React/RCTUtils.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
-
-#import <RNReanimated/NativeReanimatedModule.h>
-
 #import "HHapticModule.h"
 
 @implementation HHapticModule
@@ -33,90 +27,6 @@ RCT_EXPORT_MODULE()
 - (void)setBridge:(RCTBridge *)bridge
 {
     _bridge = bridge;
-    
-    // TODO(savelichalex): a little temporary hack to give time for runtime to initialize
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(jsLoaded:)
-                                                 name:RCTJavaScriptDidLoadNotification
-                                               object:nil];
-}
-
-- (void)jsLoaded:(NSNotification *)notification {
-    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
-    
-    if (!cxxBridge.runtime) {
-        return;
-    }
-    
-    jsi::Runtime *runtime = reinterpret_cast<facebook::jsi::Runtime *>(cxxBridge.runtime);
-    
-    jsi::Object reanimatedModuleProxy = runtime->global().getPropertyAsObject(*runtime, "__reanimatedModuleProxy");
-    std::shared_ptr<reanimated::NativeReanimatedModule> reanimatedModule = std::static_pointer_cast<reanimated::NativeReanimatedModule>(reanimatedModuleProxy.getHostObject(*runtime));
-    
-    jsi::Runtime &reanimatedUIRuntime = *reanimatedModule->runtime.get();
-    
-    HHapticModule *_this = self;
-    
-    auto hapticImpactCallback = [_this](
-                                        jsi::Runtime& rt,
-                                        const jsi::Value& thisVal,
-                                        const jsi::Value *args,
-                                        size_t count
-                                        ) -> jsi::Value {
-        const auto inputStyle = args[0].asString(rt);
-        
-        [_this hapticImpact:[NSString stringWithUTF8String:inputStyle.utf8(rt).c_str()]];
-        
-        return jsi::Value::undefined();
-    };
-    
-    jsi::Value hapticImpact = jsi::Function::createFromHostFunction(
-                                                                    reanimatedUIRuntime,
-                                                                    jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticImpact"),
-                                                                    1,
-                                                                    hapticImpactCallback);
-    
-    reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticImpact", hapticImpact);
-    
-    auto hapticSelectionCallback = [_this](
-                                           jsi::Runtime& rt,
-                                           const jsi::Value& thisVal,
-                                           const jsi::Value *args,
-                                           size_t count
-                                           ) -> jsi::Value {
-        [_this hapticSelection];
-        
-        return jsi::Value::undefined();
-    };
-    
-    jsi::Value hapticSelection = jsi::Function::createFromHostFunction(
-                                                                       reanimatedUIRuntime,
-                                                                       jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticSelection"),
-                                                                       0,
-                                                                       hapticSelectionCallback);
-    
-    reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticSelection", hapticSelection);
-    
-    auto hapticNotificationCallback = [_this](
-                                              jsi::Runtime& rt,
-                                              const jsi::Value& thisVal,
-                                              const jsi::Value *args,
-                                              size_t count
-                                              ) -> jsi::Value {
-        const auto inputType = args[0].asString(rt);
-        
-        [_this hapticNotification:[NSString stringWithUTF8String:inputType.utf8(rt).c_str()]];
-        
-        return jsi::Value::undefined();
-    };
-    
-    jsi::Value hapticNotification = jsi::Function::createFromHostFunction(
-                                                                          reanimatedUIRuntime,
-                                                                          jsi::PropNameID::forAscii(reanimatedUIRuntime, "_hapticNotification"),
-                                                                          1,
-                                                                          hapticNotificationCallback);
-    
-    reanimatedUIRuntime.global().setProperty(reanimatedUIRuntime, "_hapticNotification", hapticNotification);
 }
 
 - (void)hapticImpact:(NSString *)inputStyle {
@@ -179,7 +89,7 @@ RCT_EXPORT_MODULE()
 
 -(Boolean)supportsHapticFor6SAnd6SPlus {
     return ([[self platform] isEqualToString:@"iPhone8,1"]  // iPhone 6S
-        || [[self platform] isEqualToString:@"iPhone8,2"]); // iPhone 6S Plus
+            || [[self platform] isEqualToString:@"iPhone8,2"]); // iPhone 6S Plus
 }
 
 - (NSString *)platform {

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -62,7 +62,7 @@
     "react-native-fast-image": "^8.3.4",
     "react-native-gesture-handler": "1.10.3",
     "react-native-permissions": "3.0.0",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-redash": "16.0.11",
     "ts-jest": "26.5.6",
@@ -78,7 +78,7 @@
     "react-native-fast-image": "^8.3.4",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-permissions": "^3.0.0",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-redash": "16.0.11"
   },

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -50,7 +50,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-android-keyboard-adjust": "1.2.0",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "typescript": "4.2.4"
   },
@@ -60,7 +60,7 @@
     "react-dom": "^17.0.1",
     "react-native": "^0.64.2",
     "react-native-android-keyboard-adjust": "^1.2.0",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3"
   },
   "@react-native-community/bob": {

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -63,7 +63,7 @@
     "react-native": "0.64.2",
     "react-native-navigation-bar-color": "2.0.1",
     "react-native-qrcode-scanner": "^1.5.4",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-screens": "^3.3.0",
     "typescript": "^4.0.3"
@@ -75,7 +75,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-navigation-bar-color": "^2.0.1",
     "react-native-qrcode-scanner": "^1.5.4",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3",
     "react-native-screens": "^3.3.0"
   },

--- a/packages/popups/package.json
+++ b/packages/popups/package.json
@@ -48,7 +48,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3"
   },
   "peerDependencies": {
@@ -56,7 +56,7 @@
     "react-dom": "^17.0.1",
     "react-native": "^0.64.2",
     "react-native-gesture-handler": "^1.10.3",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.3.0-alpha.2",
     "react-native-safe-area-context": "^3.1.3"
   },
   "@react-native-community/bob": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9738,6 +9738,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
@@ -12413,13 +12418,14 @@ react-native-qrcode-scanner@1.5.4, react-native-qrcode-scanner@^1.5.4:
     prop-types "^15.5.10"
     react-native-permissions "^2.0.2"
 
-react-native-reanimated@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.2.0.tgz#a6412c56b4e591d1f00fac949f62d0c72c357c78"
-  integrity sha512-lOJDd+5w1gY6DHGXG2jD1dsjzQmXQ2699HUc3IztvI2WP4zUT+UAA+zSG+5JiBS5DUnTL8YhhkmUQmr1KNGO5w==
+react-native-reanimated@2.3.0-alpha.2:
+  version "2.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.0-alpha.2.tgz#2bd0655f7a3b90606f93c59199a99885ee72b745"
+  integrity sha512-SpzW1rPMjpy7dMEKo30873pmgj0cgczBgUHvrOKKCCPJbaQXR6w6pOGrTW5M6BQtM8zpIPPwSJN+p3G9W49aiA==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.10.4"
-    fbjs "^3.0.0"
+    invariant "^2.2.4"
+    lodash.isequal "^4.5.0"
     mockdate "^3.0.2"
     string-hash-64 "^1.0.3"
 


### PR DESCRIPTION
Hermes has a check in debug mode for execution in runtime,
a call to it's methods should be on the same thread it was created.
If we tried to bind JSI methods from a RN native module it would be
on a different thread, therefore we have to use RCTCxxBridgeDelegate
method to set up them properly. Fortunatelly for us at the time
`react-native-reanimated` also supported this and we can safely use
it, but it requires us to have `reanimated` version no less than
`2.3.0-alpha.2`.