### PR TITLE
Enable disallowInterruption for ScrollView on Android

### DIFF
--- a/packages/navigation/src/Scrollable/wrapScrollableComponent/wrapScrollableComponent.android.tsx
+++ b/packages/navigation/src/Scrollable/wrapScrollableComponent/wrapScrollableComponent.android.tsx
@@ -61,7 +61,7 @@ export function wrapScrollableComponent<Props extends ScrollViewProps>(
                 <Animated.View style={{ flex: 1 }}>
                     <NativeViewGestureHandler
                         ref={nativeGestureRef}
-                        disallowInterruption={false}
+                        disallowInterruption={true}
                         shouldCancelWhenOutside={false}
                     >
                         {/* @ts-ignore */}


### PR DESCRIPTION
This is not gonna fix all issues, but it's a quick fix, probably to make better I would need to extend `ReactScrollView.java` and make the behaviour of scroll events behave as it works on iOS and get rid of `PanResponderHandler` there.