### PR TITLE
RTL support to balance component added

### DIFF
--- a/packages/core/src/UIStyle/UIStyleCommon.js
+++ b/packages/core/src/UIStyle/UIStyleCommon.js
@@ -98,6 +98,9 @@ export default class UIStyleCommon {
     static flexRow() {
         return styles.flexRow;
     }
+    static flexRowReverse() {
+        return styles.flexRowReverse;
+    }
     static flexRowWrap() {
         return styles.flexRowWrap;
     }

--- a/packages/core/src/UIStyle/UIStyleFlex.js
+++ b/packages/core/src/UIStyle/UIStyleFlex.js
@@ -15,6 +15,9 @@ export const flexStyles = {
     flexRow: {
         flexDirection: 'row',
     },
+    flexRowReverse: {
+        flexDirection: 'row-reverse',
+    },
     flexColumn: {
         flexDirection: 'column',
     },
@@ -95,6 +98,10 @@ export default class UIStyleFlex {
 
     static row() {
         return styles.flexRow;
+    }
+
+    static rowReverse() {
+        return styles.flexRowReverse;
     }
 
     static rowWrap() {

--- a/packages/legacy/src/UIAnimatedBalanceView/UIAnimatedBalanceOpacity.js
+++ b/packages/legacy/src/UIAnimatedBalanceView/UIAnimatedBalanceOpacity.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { Animated, StyleSheet, Text, View } from 'react-native';
+import { Animated, StyleSheet, Text, View, I18nManager } from 'react-native';
 
 import type AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 import type AnimatedInterpolation from 'react-native/Libraries/Animated/src/nodes/AnimatedInterpolation';
@@ -223,7 +223,7 @@ export default class UIAnimatedBalanceOpacity extends React.Component<
                     {this.props.balance}
                 </Text>
                 <View
-                    style={[StyleSheet.absoluteFill, UIStyle.common.flexRow()]}
+                    style={[StyleSheet.absoluteFill, I18nManager.isRTL ? UIStyle.common.flexRowReverse() : UIStyle.common.flexRow()}]}
                     onLayout={this.onBalanceLayout}
                 >
                     {this.state.nextBalance.map((symbol, index) => (
@@ -244,7 +244,7 @@ export default class UIAnimatedBalanceOpacity extends React.Component<
                     <View
                         style={[
                             StyleSheet.absoluteFill,
-                            UIStyle.common.flexRow(),
+                            I18nManager.isRTL ? UIStyle.common.flexRowReverse() : UIStyle.common.flexRow()},
                         ]}
                     >
                         {this.state.prevBalance.map((symbol, index) => (


### PR DESCRIPTION
Balance component is shown in reverse on RTL locales. This PR is fixing this by using row-reverse when direction is RTL.