### PR TITLE
Make a constructor out of UISheet to support different behaviours

### DIFF
--- a/casts/countryPicker/src/UICountryPicker/CountryPicker.tsx
+++ b/casts/countryPicker/src/UICountryPicker/CountryPicker.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import Fuse from 'fuse.js';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, useWindowDimensions, Platform, Keyboard } from 'react-native';
+import { View, Platform, Keyboard } from 'react-native';
 import AndroidKeyboardAdjust from 'react-native-android-keyboard-adjust';
 
 import { UIConstant } from '@tonlabs/uikit.core';
 import { uiLocalized } from '@tonlabs/localization';
 import { UISearchBar } from '@tonlabs/uicast.bars';
-import { UIBottomSheet } from '@tonlabs/uikit.popups';
+import { UIFullscreenSheet } from '@tonlabs/uikit.popups';
 import { FlatList } from '@tonlabs/uikit.scrolls';
 import { UILinkButton } from '@tonlabs/uikit.controls';
 import {
@@ -52,10 +52,8 @@ export function CountryPicker({
     banned = [],
     permitted = [],
 }: WrappedCountryPickerProps) {
-    const { height } = useWindowDimensions();
-
     const theme = useTheme();
-    const styles = useStyles(theme, height);
+    const styles = useStyles(theme);
 
     const [loading, setLoading] = React.useState(true);
 
@@ -167,12 +165,7 @@ export function CountryPicker({
     const keyExtractor = React.useCallback((item: Country) => item.code, []);
 
     return (
-        <UIBottomSheet
-            onClose={onClose}
-            visible={visible}
-            style={styles.sheet}
-            shouldHandleKeyboard={false}
-        >
+        <UIFullscreenSheet onClose={onClose} visible={visible} style={styles.sheet}>
             {renderSearchHeader()}
             <CountryPickerContext.Provider value={{ loading, onSelect }}>
                 <FlatList
@@ -185,15 +178,14 @@ export function CountryPicker({
                     onMomentumScrollBegin={hideKeyboard}
                 />
             </CountryPickerContext.Provider>
-        </UIBottomSheet>
+        </UIFullscreenSheet>
     );
 }
 
-const useStyles = makeStyles((theme: Theme, height: number) => ({
+const useStyles = makeStyles((theme: Theme) => ({
     sheet: {
         backgroundColor: theme[ColorVariants.BackgroundPrimary] as string,
         borderRadius: 10,
-        height,
     },
     headerContainer: {
         backgroundColor: theme[ColorVariants.BackgroundPrimary] as string,

--- a/kit/popups/src/Sheets/UIBottomSheet.tsx
+++ b/kit/popups/src/Sheets/UIBottomSheet.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
 import { UILayoutConstant } from '@tonlabs/uikit.layout';
+
 import { UISheet, UISheetProps } from './UISheet/UISheet';
 
 export type UIBottomSheetProps = UISheetProps & {
@@ -8,10 +11,28 @@ export type UIBottomSheetProps = UISheetProps & {
 };
 
 export function UIBottomSheet({ children, style, ...rest }: UIBottomSheetProps) {
+    const { visible, forId } = rest;
+
+    const { bottom: bottomInset } = useSafeAreaInsets();
+
+    const sheetStyle = React.useMemo(() => {
+        const flattenStyle = StyleSheet.flatten(style);
+
+        return {
+            paddingBottom:
+                Math.max(bottomInset || 0, (flattenStyle.paddingBottom as number) ?? 0) +
+                UILayoutConstant.rubberBandEffectDistance,
+        };
+    }, [style, bottomInset]);
+
     return (
-        <UISheet {...rest} countRubberBandDistance style={[styles.bottom, style]}>
-            {children}
-        </UISheet>
+        <UISheet.Container visible={visible} forId={forId}>
+            <UISheet.KeyboardAware defaultShift={-UILayoutConstant.rubberBandEffectDistance}>
+                <UISheet.Content {...rest} style={[styles.bottom, style, sheetStyle]}>
+                    {children}
+                </UISheet.Content>
+            </UISheet.KeyboardAware>
+        </UISheet.Container>
     );
 }
 

--- a/kit/popups/src/Sheets/UICardSheet.tsx
+++ b/kit/popups/src/Sheets/UICardSheet.tsx
@@ -6,11 +6,29 @@ import { UISheet, UISheetProps } from './UISheet/UISheet';
 
 export type UICardSheetProps = UISheetProps & { style?: StyleProp<ViewStyle> };
 
+// @inline
+const CARD_SHEET_DEFAULT_BOTTOM_INSET = 16; // UILayoutConstant.contentOffset
+
+function getCardSheetBottomInset(bottomInset: number, keyboardHeight: number) {
+    'worklet';
+
+    if (keyboardHeight !== 0) {
+        return CARD_SHEET_DEFAULT_BOTTOM_INSET;
+    }
+
+    return Math.max(CARD_SHEET_DEFAULT_BOTTOM_INSET, bottomInset);
+}
+
 export function UICardSheet({ children, style, ...rest }: UICardSheetProps) {
+    const { visible, forId } = rest;
     return (
-        <UISheet {...rest} style={[styles.card]}>
-            <View style={[style, styles.cardInner]}>{children}</View>
-        </UISheet>
+        <UISheet.Container visible={visible} forId={forId}>
+            <UISheet.KeyboardAware getBottomInset={getCardSheetBottomInset}>
+                <UISheet.Content {...rest} style={styles.card}>
+                    <View style={[style, styles.cardInner]}>{children}</View>
+                </UISheet.Content>
+            </UISheet.KeyboardAware>
+        </UISheet.Container>
     );
 }
 

--- a/kit/popups/src/Sheets/UIFullscreenSheet.tsx
+++ b/kit/popups/src/Sheets/UIFullscreenSheet.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-    StyleProp,
-    StyleSheet,
-    ViewStyle,
-    View,
-    StatusBar,
-    useWindowDimensions,
-} from 'react-native';
+import { StyleProp, StyleSheet, ViewStyle, StatusBar, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { UILayoutConstant } from '@tonlabs/uikit.layout';
@@ -18,38 +11,32 @@ export type UIFullscreenSheetProps = Omit<UISheetProps, 'countRubberBandDistance
 
 export function UIFullscreenSheet({ children, style, ...rest }: UIFullscreenSheetProps) {
     const { height } = useWindowDimensions();
-    const { top: topInset, bottom: bottomInset } = useSafeAreaInsets();
-    const flattenStyle = StyleSheet.flatten(style);
+    const { top: topInset } = useSafeAreaInsets();
 
-    const passedPaddingBottom = Math.max(
-        bottomInset || 0,
-        (flattenStyle.paddingBottom as number) ?? (flattenStyle.padding as number) ?? 0,
-    );
-    const passedPaddingTop =
-        (flattenStyle.paddingTop as number) ?? (flattenStyle.padding as number) ?? 0;
+    const sheetStyle = React.useMemo(() => {
+        const flattenStyle = StyleSheet.flatten(style);
+        const paddingBottom =
+            Math.max((flattenStyle.paddingBottom as number) ?? 0) +
+            UILayoutConstant.rubberBandEffectDistance;
 
-    const sheetStyle = React.useMemo(
-        () => ({
-            paddingBottom: passedPaddingBottom + UILayoutConstant.rubberBandEffectDistance,
-        }),
-        [passedPaddingBottom],
-    );
-
-    const innerStyle = React.useMemo(
-        () => ({
+        return {
+            paddingBottom,
             height:
                 height -
-                Math.max(StatusBar.currentHeight ?? 0, topInset) -
-                passedPaddingBottom -
-                passedPaddingTop,
-        }),
-        [height, topInset, passedPaddingBottom, passedPaddingTop],
-    );
+                Math.max(StatusBar.currentHeight ?? 0, topInset) +
+                UILayoutConstant.rubberBandEffectDistance,
+        };
+    }, [style, height, topInset]);
 
+    const { visible, forId } = rest;
     return (
-        <UISheet {...rest} countRubberBandDistance style={[styles.bottom, style, sheetStyle]}>
-            <View style={innerStyle}>{children}</View>
-        </UISheet>
+        <UISheet.Container visible={visible} forId={forId}>
+            <UISheet.KeyboardUnaware defaultShift={-UILayoutConstant.rubberBandEffectDistance}>
+                <UISheet.Content {...rest} style={[styles.bottom, style, sheetStyle]}>
+                    {children}
+                </UISheet.Content>
+            </UISheet.KeyboardUnaware>
+        </UISheet.Container>
     );
 }
 

--- a/kit/popups/src/Sheets/UISheet/KeyboardAwareSheet.tsx
+++ b/kit/popups/src/Sheets/UISheet/KeyboardAwareSheet.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import type Animated from 'react-native-reanimated';
+import { useDerivedValue } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useAnimatedKeyboardHeight } from '@tonlabs/uikit.inputs';
+
+function getZeroBottomInset() {
+    'worklet';
+
+    return 0;
+}
+
+type KeyboardAwareSheetContextT = {
+    origin: Animated.SharedValue<number>;
+    bottomInset: Animated.SharedValue<number>;
+};
+
+const KeyboardAwareSheetContext = React.createContext<KeyboardAwareSheetContextT | null>(null);
+
+export function useKeyboardAwareSheet() {
+    const opts = React.useContext(KeyboardAwareSheetContext);
+
+    if (opts == null) {
+        throw new Error(
+            'Have you forgot to wrap <UISheet.Content /> with <UISheet.Keyboard[Un]aware /> ?',
+        );
+    }
+
+    return opts;
+}
+
+type KeyboardAwareSheetProps = {
+    children: React.ReactNode;
+    defaultShift?: number;
+    /**
+     * IMPORTANT: should be a worklet!
+     */
+    getBottomInset?: (bottomInset: number, keyboardHeight: number) => number;
+};
+
+export function KeyboardAwareSheet({
+    children,
+    defaultShift = 0,
+    getBottomInset = getZeroBottomInset,
+}: KeyboardAwareSheetProps) {
+    const keyboardHeight = useAnimatedKeyboardHeight();
+
+    const origin = useDerivedValue(() => {
+        return 0 - defaultShift - keyboardHeight.value;
+    });
+
+    const insets = useSafeAreaInsets();
+
+    const bottomInset = useDerivedValue(() => {
+        return getBottomInset(insets.bottom, keyboardHeight.value);
+    });
+
+    const contextValue = React.useRef<KeyboardAwareSheetContextT>();
+
+    if (contextValue.current == null) {
+        contextValue.current = {
+            origin,
+            bottomInset,
+        };
+    }
+
+    return (
+        <KeyboardAwareSheetContext.Provider value={contextValue.current}>
+            {children}
+        </KeyboardAwareSheetContext.Provider>
+    );
+}
+
+export function KeyboardUnawareSheet({
+    children,
+    defaultShift = 0,
+    getBottomInset = getZeroBottomInset,
+}: KeyboardAwareSheetProps) {
+    const origin = useDerivedValue(() => {
+        return 0 - defaultShift;
+    });
+
+    const insets = useSafeAreaInsets();
+
+    const bottomInset = useDerivedValue(() => {
+        return getBottomInset(insets.bottom, 0);
+    });
+
+    const contextValue = React.useRef<KeyboardAwareSheetContextT>();
+
+    if (contextValue.current == null) {
+        contextValue.current = {
+            origin,
+            bottomInset,
+        };
+    }
+
+    return (
+        <KeyboardAwareSheetContext.Provider value={contextValue.current}>
+            {children}
+        </KeyboardAwareSheetContext.Provider>
+    );
+}

--- a/kit/popups/src/Sheets/UISheet/UISheet.tsx
+++ b/kit/popups/src/Sheets/UISheet/UISheet.tsx
@@ -2,31 +2,20 @@ import * as React from 'react';
 import { View, StyleSheet, ViewStyle, StyleProp, Platform, Keyboard } from 'react-native';
 import { PanGestureHandler, TapGestureHandler } from 'react-native-gesture-handler';
 import Animated, { interpolateColor, useAnimatedStyle } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useBackHandler } from '@react-native-community/hooks';
 
-import { Portal, UILayoutConstant } from '@tonlabs/uikit.layout';
+import { Portal } from '@tonlabs/uikit.layout';
 import { ColorVariants, useColorParts, useStatusBar } from '@tonlabs/uikit.themes';
-import { useAnimatedKeyboardHeight } from '@tonlabs/uikit.inputs';
 
 import { ScrollableContext } from '@tonlabs/uikit.scrolls';
 import { useSheetHeight } from './useSheetHeight';
 import type { OnOpen, OnClose } from './types';
 import { usePosition } from './usePosition';
-
-function useBottomInsetStyle(countRubberBandDistance: boolean = false) {
-    const { bottom } = useSafeAreaInsets();
-
-    return React.useMemo(() => {
-        let paddingBottom = Math.max(bottom, UILayoutConstant.contentOffset);
-        if (countRubberBandDistance) {
-            paddingBottom += UILayoutConstant.rubberBandEffectDistance;
-        }
-        return {
-            paddingBottom,
-        };
-    }, [bottom, countRubberBandDistance]);
-}
+import {
+    KeyboardAwareSheet,
+    KeyboardUnawareSheet,
+    useKeyboardAwareSheet,
+} from './KeyboardAwareSheet';
 
 export type UISheetProps = {
     /**
@@ -56,9 +45,6 @@ export type UISheetProps = {
      * Styles for container
      */
     style?: StyleProp<ViewStyle>;
-    // advanced
-    // not for public use
-    countRubberBandDistance?: boolean;
     /**
      * Whether UISheet has open animation or not
      */
@@ -68,46 +54,49 @@ export type UISheetProps = {
      */
     hasCloseAnimation?: boolean;
     /**
-     * Whether UISheet should react on keyboard opening
-     *
-     * TODO(savelichalex): I was thinking maybe do it a bit smarter,
-     * but for now left it simple. So the idea was:
-     * Maybe measure the size of the container somehow and see if it
-     * can fit into the area between top safe area edge and bottom when
-     * keyboard is opened, and if it can't fit, disable reacting on keyboard.
-     * But it actually produces new question, like what if the conditions are met
-     * but I want the container to be shrinked instead and still react on keyboard?
-     */
-    shouldHandleKeyboard?: boolean;
-    /**
-     * See Portal
+     * Sheet uses <Portal /> to put itself on top of
+     * current components, like a layer.
+     * Use the ID if you want to change destination where
+     * Sheet should be put (i.e. you have another <PortalManager />)
      */
     forId?: string;
 };
 
-type UISheetPortalContentProps = UISheetProps & {
-    onClosePortalRequest: () => void;
-};
+const SheetClosePortalRequestContext = React.createContext(() => {
+    /* no-op */
+});
 
-function UISheetPortalContent({
+function useSheetClosePortalRequest() {
+    const onClose = React.useContext(SheetClosePortalRequestContext);
+
+    if (onClose == null) {
+        throw new Error('Have you forgot to wrap <UISheet.Content /> with <UISheet.Container /> ?');
+    }
+
+    return onClose;
+}
+
+function SheetContent({
     visible,
     onClose,
     onOpenEnd,
     onCloseEnd,
     children,
-    onClosePortalRequest,
     style,
-    countRubberBandDistance,
     hasOpenAnimation,
     hasCloseAnimation,
-    shouldHandleKeyboard,
-}: UISheetPortalContentProps) {
-    const { height, onSheetLayout } = useSheetHeight(
-        UILayoutConstant.rubberBandEffectDistance,
-        countRubberBandDistance,
-    );
-    const keyboardHeight = useAnimatedKeyboardHeight();
-    const contentStyle = useBottomInsetStyle(countRubberBandDistance);
+}: UISheetProps) {
+    const onClosePortalRequest = useSheetClosePortalRequest();
+    const { origin, bottomInset } = useKeyboardAwareSheet();
+
+    /**
+     * TODO: looks like it's not needed for UIFullscreenSheet,
+     * as it's height can be calculated from insets
+     *
+     * Maybe it's a good idea to split this logic too, and pass
+     * it from the outside
+     */
+    const { height, onSheetLayout } = useSheetHeight();
 
     const {
         animate,
@@ -121,12 +110,10 @@ function UISheetPortalContent({
         position,
     } = usePosition(
         height,
-        keyboardHeight,
-        contentStyle.paddingBottom,
+        origin,
+        bottomInset,
         hasOpenAnimation,
         hasCloseAnimation,
-        shouldHandleKeyboard,
-        countRubberBandDistance,
         onClose,
         onClosePortalRequest,
         onOpenEnd,
@@ -151,13 +138,13 @@ function UISheetPortalContent({
         return false;
     });
 
-    const { colorParts: overlayColorParts, opacity: overlayOpacity } = useColorParts(
-        ColorVariants.BackgroundOverlay,
-    );
-
     useStatusBar({
         backgroundColor: ColorVariants.BackgroundOverlay,
     });
+
+    const { colorParts: overlayColorParts, opacity: overlayOpacity } = useColorParts(
+        ColorVariants.BackgroundOverlay,
+    );
 
     const overlayStyle = useAnimatedStyle(() => {
         return {
@@ -237,7 +224,7 @@ function UISheetPortalContent({
                         ? { waitFor: scrollPanGestureHandlerRef }
                         : null)}
                 >
-                    <Animated.View style={[style, contentStyle]}>
+                    <Animated.View style={style}>
                         <ScrollableContext.Provider value={scrollableContextValue}>
                             {children}
                         </ScrollableContext.Provider>
@@ -248,8 +235,10 @@ function UISheetPortalContent({
     );
 }
 
-export function UISheet(props: UISheetProps) {
-    const { visible, forId } = props;
+function SheetContainer(
+    props: Pick<UISheetProps, 'visible' | 'forId'> & { children: React.ReactNode },
+) {
+    const { visible, forId, children } = props;
     const [isVisible, setIsVisible] = React.useState(false);
 
     React.useEffect(() => {
@@ -273,10 +262,19 @@ export function UISheet(props: UISheetProps) {
 
     return (
         <Portal absoluteFill forId={forId}>
-            <UISheetPortalContent {...props} onClosePortalRequest={onClosePortalRequest} />
+            <SheetClosePortalRequestContext.Provider value={onClosePortalRequest}>
+                {children}
+            </SheetClosePortalRequestContext.Provider>
         </Portal>
     );
 }
+
+export const UISheet = {
+    Container: SheetContainer,
+    Content: SheetContent,
+    KeyboardAware: KeyboardAwareSheet,
+    KeyboardUnaware: KeyboardUnawareSheet,
+};
 
 const styles = StyleSheet.create({
     container: {

--- a/kit/popups/src/Sheets/UISheet/useSheetHeight.tsx
+++ b/kit/popups/src/Sheets/UISheet/useSheetHeight.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { useSharedValue } from 'react-native-reanimated';
 
-export function useSheetHeight(
-    rubberBandEffectDistance: number,
-    countRubberBandDistance?: boolean,
-) {
+export function useSheetHeight() {
     const height = useSharedValue(0);
     const onSheetLayout = React.useCallback(
         ({
@@ -12,12 +9,9 @@ export function useSheetHeight(
                 layout: { height: lHeight },
             },
         }) => {
-            const newHeight = countRubberBandDistance
-                ? lHeight - rubberBandEffectDistance
-                : lHeight;
-            height.value = newHeight;
+            height.value = lHeight;
         },
-        [height, countRubberBandDistance, rubberBandEffectDistance],
+        [height],
     );
 
     return {


### PR DESCRIPTION
Not every `Sheet` need the ability to handle a keyboard events (i.e. UIFullscreenSheet shouldn't adjust their position with keyboard opening), but it was built in core logic of the base `Sheet`, hence for UIFullscreen (and therefore for every modal in the app) it would have piece of code that just takes resources. So because of that I split implementation, and now `Sheet` can be composed from pieces that include only needed functionality.