### PR TITLE
Better error handling for RefreshControl

### DIFF
--- a/casts/bars/src/UILargeTitleHeader/RefreshControl.tsx
+++ b/casts/bars/src/UILargeTitleHeader/RefreshControl.tsx
@@ -52,7 +52,7 @@ export function RefreshControl({
         await new Promise(res => requestAnimationFrame(res));
 
         try {
-            await Promise.all([
+            await Promise.allSettled([
                 onRefresh(),
                 // An artificial timeout is needed
                 // in case the refresh is super fast


### PR DESCRIPTION
`Promise.all` immediately `reject` returned `Promise` if one of promises it waits is rejected. But we need `timeout` to be awaited, `allSettled` does just that