### PR TITLE
Fix default stack header buttons

### DIFF
--- a/casts/splitNavigator/src/SplitNavigator/createSplitNavigator.tsx
+++ b/casts/splitNavigator/src/SplitNavigator/createSplitNavigator.tsx
@@ -548,7 +548,7 @@ export function SplitNavigator({
     const descriptors = useWrapScreensWithUILargeTitleHeader<
         SplitScreenOptions,
         SplitNavigationState
-    >(rawDescriptors, !isSplitted);
+    >(state, rawDescriptors, !isSplitted);
 
     const mainRoute = state.routes.find(({ name }: { name: string }) => name === MAIN_SCREEN_NAME);
     if (mainRoute == null) {

--- a/casts/stackNavigator/src/StackNavigator/createStackNavigator.tsx
+++ b/casts/stackNavigator/src/StackNavigator/createStackNavigator.tsx
@@ -90,7 +90,7 @@ export const StackNavigator = ({
         [navigation, state.index, state.key],
     );
 
-    const descriptors = useWrapScreensWithUILargeTitleHeader(rawDescriptors);
+    const descriptors = useWrapScreensWithUILargeTitleHeader(state, rawDescriptors);
 
     if (doesSupportNative) {
         // TODO: check, maybe we don't need it anymore


### PR DESCRIPTION
So the previous way to find out a current route index was a pretty fragile, working by a chance, way to do it. Now it should be correct.