### PR TITLE
Fix UIAccortionSectionList crash

### DIFF
--- a/kit/scrolls/ios/UIKitAccordionOverlayView.m
+++ b/kit/scrolls/ios/UIKitAccordionOverlayView.m
@@ -173,7 +173,11 @@
     
     UIScrollView *scrollView = ((RCTScrollView *)view).scrollView;
     
-    [scrollView removeObserver:self forKeyPath:@"contentOffset" context:nil];
+    @try {
+        [scrollView removeObserver:self forKeyPath:@"contentOffset" context:nil];
+    }@catch(id exception) {
+        // do nothing, as it appears there wasn't an observer attached
+    }
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {


### PR DESCRIPTION
It fixes a crash, though it doesn't help to understand a question HOW has it happen. It's doesn't make any sense when you read the code (and a bit of debugging), therefore there is some problem deeper.