### PR TITLE
Move more input handlers to UI thread

### DIFF
--- a/Example/src/components/ExampleScreen.tsx
+++ b/Example/src/components/ExampleScreen.tsx
@@ -19,6 +19,7 @@ export function ExampleScreen({
                     alignItems: 'center',
                 }}
                 automaticallyAdjustContentInsets
+                automaticallyAdjustKeyboardInsets
                 {...rest}
             >
                 {children}

--- a/casts/keyboard/package.json
+++ b/casts/keyboard/package.json
@@ -36,7 +36,8 @@
     "dependencies": {
         "@react-native-community/hooks": "^2.6.0",
         "@tonlabs/uikit.core": "^4.0.0",
-        "@tonlabs/uikit.themes": "^3.1.0"
+        "@tonlabs/uikit.themes": "^3.1.0",
+        "@tonlabs/uikit.inputs": "^3.1.0"
     },
     "devDependencies": {
         "@types/react": "17.0.44",

--- a/kit/inputs/src/MaterialTextView/MaterialTextViewFloating/MaterialTextViewFloating.tsx
+++ b/kit/inputs/src/MaterialTextView/MaterialTextViewFloating/MaterialTextViewFloating.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { View } from 'react-native';
+
 import { UILayoutConstant } from '@tonlabs/uikit.layout';
 import { makeStyles, useTheme, Theme, ColorVariants } from '@tonlabs/uikit.themes';
-import Animated, { interpolate, useAnimatedStyle /* , Layout */ } from 'react-native-reanimated';
+import Animated, { interpolate, useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
 import { UITextView, UITextViewRef } from '../../UITextView';
 import { FloatingLabel } from './FloatingLabel';
 import type { MaterialTextViewLayoutProps } from '../types';
@@ -21,6 +22,8 @@ const POSITION_EXPANDED: number = 1;
 // @inline
 const EXPANDED_INPUT_OFFSET: number = 8;
 
+const UITextViewAnimated = Animated.createAnimatedComponent(UITextView);
+
 export const MaterialTextViewFloating = React.forwardRef<
     UITextViewRef,
     MaterialTextViewLayoutProps
@@ -32,13 +35,14 @@ export const MaterialTextViewFloating = React.forwardRef<
         onMouseLeave,
         borderViewRef,
         isHovered,
-        inputHasValue,
+        hasValue,
         isFocused,
         ...rest
     } = props;
     const theme = useTheme();
 
-    const isExpanded = React.useMemo(() => isFocused || inputHasValue, [isFocused, inputHasValue]);
+    const isExpanded = useDerivedValue(() => isFocused.value || hasValue.value);
+
     const { isPlaceholderVisible, showPlacehoder } = usePlaceholderVisibility(isExpanded);
 
     const expandingValue: Readonly<Animated.SharedValue<number>> = useExpandingValue(
@@ -79,7 +83,7 @@ export const MaterialTextViewFloating = React.forwardRef<
                 ref={borderViewRef}
             >
                 <Animated.View style={[styles.input, inputStyle]} /* layout={Layout} */>
-                    <UITextView
+                    <UITextViewAnimated
                         ref={ref}
                         {...rest}
                         placeholder={props.placeholder}

--- a/kit/inputs/src/MaterialTextView/MaterialTextViewFloating/hooks/usePlaceholderVisibility.ts
+++ b/kit/inputs/src/MaterialTextView/MaterialTextViewFloating/hooks/usePlaceholderVisibility.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { runOnJS, SharedValue, useAnimatedReaction } from 'react-native-reanimated';
 
-export function usePlaceholderVisibility(isExpanded: boolean) {
-    const [isPlaceholderVisible, setPlaceholderVisible] = React.useState(isExpanded);
+export function usePlaceholderVisibility(isExpanded: SharedValue<boolean>) {
+    const [isPlaceholderVisible, setPlaceholderVisible] = React.useState(isExpanded.value);
 
     /**
      * We need to show the placeholder after the expanding animation ends
@@ -10,18 +11,24 @@ export function usePlaceholderVisibility(isExpanded: boolean) {
         setPlaceholderVisible(true);
     }, []);
 
-    React.useEffect(() => {
-        /**
-         * We need to hide the placeholder before the folding animation starts
-         */
-        if (!isExpanded) {
-            setPlaceholderVisible(false);
-        }
-    }, [isExpanded]);
+    const hidePlacehoder = React.useCallback(() => {
+        setPlaceholderVisible(false);
+    }, []);
+
+    useAnimatedReaction(
+        () => isExpanded.value,
+        (expanded, prevExpanded) => {
+            if (expanded === prevExpanded) {
+                return;
+            }
+            if (!expanded) {
+                runOnJS(hidePlacehoder)();
+            }
+        },
+    );
 
     return {
         isPlaceholderVisible,
         showPlacehoder,
-        isExpanded,
     };
 }

--- a/kit/inputs/src/MaterialTextView/hooks/useApplyMask/amount/useApplyMaskAmount.tsx
+++ b/kit/inputs/src/MaterialTextView/hooks/useApplyMask/amount/useApplyMaskAmount.tsx
@@ -43,6 +43,8 @@ export function useApplyMaskAmount(
 
     const applyMaskAmount = React.useCallback(
         (text: string): MaterialTextViewInputState => {
+            'worklet';
+
             const { formattedText, normalizedText, carretPosition } = runUIOnChangeAmount(
                 text,
                 selectionEnd,

--- a/kit/inputs/src/MaterialTextView/hooks/useApplyMask/useApplyMask.tsx
+++ b/kit/inputs/src/MaterialTextView/hooks/useApplyMask/useApplyMask.tsx
@@ -9,6 +9,8 @@ import { useApplyMaskAmount } from './amount';
 
 function useApplyMaskDefault(): MaterialTextViewApplyMask {
     return React.useCallback((text: string): MaterialTextViewInputState => {
+        'worklet';
+
         return {
             formattedText: text,
             carretPosition: null,

--- a/kit/inputs/src/MaterialTextView/hooks/useOnSelectionChange.ts
+++ b/kit/inputs/src/MaterialTextView/hooks/useOnSelectionChange.ts
@@ -1,32 +1,33 @@
 /* eslint-disable no-param-reassign */
 import * as React from 'react';
-import type { TextInputProps } from 'react-native';
-import { useSharedValue } from 'react-native-reanimated';
+import type { TextInputProps, TextInputSelectionChangeEventData } from 'react-native';
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
 
 export function useOnSelectionChange(onSelectionChangeProp: TextInputProps['onSelectionChange']) {
     const selectionEnd = useSharedValue(0);
     const skipNextOnSelectionChange = useSharedValue(false);
 
     const onSelectionChange = React.useCallback(
-        function onSelectionChange(e) {
-            const {
-                nativeEvent: {
-                    selection: { end },
-                },
-            } = e;
+        function onSelectionChange(evt: TextInputSelectionChangeEventData) {
+            'worklet';
+
             if (skipNextOnSelectionChange.value) {
                 skipNextOnSelectionChange.value = false;
                 return;
             }
-            selectionEnd.value = end;
-            onSelectionChangeProp?.(e);
+
+            selectionEnd.value = evt.selection.end;
+
+            if (onSelectionChangeProp != null) {
+                runOnJS(onSelectionChangeProp)({ nativeEvent: evt } as any);
+            }
         },
         [selectionEnd, skipNextOnSelectionChange, onSelectionChangeProp],
     );
 
     return {
         selectionEnd,
-        onSelectionChange,
         skipNextOnSelectionChange,
+        onSelectionChange,
     };
 }

--- a/kit/inputs/src/MaterialTextView/types.ts
+++ b/kit/inputs/src/MaterialTextView/types.ts
@@ -1,6 +1,9 @@
 import type React from 'react';
 import type { View, ViewStyle, StyleProp, TextInput } from 'react-native';
+import type { SharedValue } from 'react-native-reanimated';
+
 import type { UIImageProps } from '@tonlabs/uikit.media';
+
 import type { UITextViewProps } from '../UITextView';
 
 export type MaterialTextViewAmountMask =
@@ -64,8 +67,8 @@ export type MaterialTextViewLayoutProps = MaterialTextViewProps & {
     onMouseEnter: () => void;
     onMouseLeave: () => void;
     isHovered: boolean;
-    isFocused: boolean;
-    inputHasValue: boolean;
+    isFocused: SharedValue<boolean>;
+    hasValue: SharedValue<boolean>;
 };
 
 export type MaterialTextViewRef = Pick<TextInput, 'isFocused' | 'focus' | 'blur' | 'clear'> & {

--- a/kit/inputs/src/UISeedPhraseTextView/UISeedPhrasePopover.tsx
+++ b/kit/inputs/src/UISeedPhraseTextView/UISeedPhrasePopover.tsx
@@ -20,6 +20,7 @@ type UISeedPhrasePopoverProps = {
     hints: string[];
     onHintSelected: (item: string) => void;
     forId?: string;
+    height: number;
     // width: number;
 };
 
@@ -139,14 +140,14 @@ function UISeedPhrasePopoverContent(props: UISeedPhrasePopoverProps) {
 }
 
 export function UISeedPhrasePopover(props: UISeedPhrasePopoverProps) {
-    const { hints, forId } = props;
+    const { hints, forId, height } = props;
     if (hints.length === 0) {
         return null;
     }
 
     return (
         <Portal absoluteFill forId={forId}>
-            <UISeedPhrasePopoverContent {...props} />
+            <UISeedPhrasePopoverContent key={height} {...props} />
         </Portal>
     );
 }

--- a/kit/inputs/src/UISeedPhraseTextView/UISeedPhraseTextView.tsx
+++ b/kit/inputs/src/UISeedPhraseTextView/UISeedPhraseTextView.tsx
@@ -551,9 +551,9 @@ export const UISeedPhraseTextView = React.forwardRef<
                 noPersonalizedLearning
             />
             <UISeedPhrasePopover
-                // if number of lines changed, redraw it
                 forId={forId}
-                key={height}
+                // if number of lines changed, redraw it
+                height={height}
                 elementRef={textInputBorderViewRef}
                 currentHighlightedItemIndex={state.highlight.index}
                 onHighlightedItemIndexChange={onHighlightedItemIndexChange}

--- a/kit/inputs/src/UITextView/UITextView.tsx
+++ b/kit/inputs/src/UITextView/UITextView.tsx
@@ -10,8 +10,8 @@ const textViewLineHeight =
     StyleSheet.flatten(Typography[textViewTypographyVariant]).lineHeight ??
     UILayoutConstant.smallCellHeight;
 
-export const UITextView = React.memo(
-    React.forwardRef<UITextViewRef, UITextViewProps>(function UITextViewForwarded(
+export const UITextView = React.forwardRef<UITextViewRef, UITextViewProps>(
+    function UITextViewForwarded(
         {
             placeholderTextColor = ColorVariants.TextSecondary,
             style,
@@ -77,7 +77,7 @@ export const UITextView = React.memo(
                 numberOfLines={numberOfLines}
             />
         );
-    }),
+    },
 );
 
 const styles = StyleSheet.create({

--- a/kit/inputs/src/UITextView/hooks/useHandleRef.ts
+++ b/kit/inputs/src/UITextView/hooks/useHandleRef.ts
@@ -8,6 +8,9 @@ export function useHandleRef(
     remeasureInputHeight: (() => void) | undefined,
 ) {
     React.useImperativeHandle<UITextViewRef, UITextViewRef>(passedRef, () => ({
+        // To spread actual ref is important
+        // in order to work properly with `findNodeHandle`
+        ...textInputRef.current,
         remeasureInputHeight: () => {
             return remeasureInputHeight?.();
         },

--- a/kit/inputs/src/UITextView/types.ts
+++ b/kit/inputs/src/UITextView/types.ts
@@ -64,12 +64,10 @@ export type UITextViewProps = Omit<
     onNumberOfLinesChange?: (numberOfLines: number) => void;
 };
 
-export type UITextViewRef = Pick<
-    TextInput,
-    'isFocused' | 'focus' | 'blur' | 'clear' | 'setNativeProps'
-> & {
+export interface UITextViewRef
+    extends Pick<TextInput, 'isFocused' | 'focus' | 'blur' | 'clear' | 'setNativeProps'> {
     remeasureInputHeight: () => void;
-};
+}
 
 export type AutogrowAttributes = {
     onChange: ((event: NativeSyntheticEvent<TextInputChangeEventData>) => void) | undefined;

--- a/kit/inputs/src/useTextViewHandler.ts
+++ b/kit/inputs/src/useTextViewHandler.ts
@@ -1,0 +1,63 @@
+import type {
+    TextInputChangeEventData,
+    TextInputFocusEventData,
+    TextInputSelectionChangeEventData,
+} from 'react-native';
+import { useEvent, useHandler } from 'react-native-reanimated';
+
+export function useTextViewHandler<Context extends Record<string, unknown>>(
+    handlers:
+        | {
+              onFocus?: (evt: TextInputFocusEventData, ctx: Context) => void;
+              onBlur?: (evt: TextInputFocusEventData, ctx: Context) => void;
+              onChange?: (evt: TextInputChangeEventData, ctx: Context) => void;
+              onSelectionChange?: (evt: TextInputSelectionChangeEventData, ctx: Context) => void;
+          }
+        | ((evt: TextInputChangeEventData) => void),
+    dependencies?: Array<unknown>,
+) {
+    const textViewHandlers = typeof handlers === 'function' ? { onChange: handlers } : handlers;
+    const { context, doDependenciesDiffer } = useHandler<any, Context>(
+        textViewHandlers,
+        dependencies,
+    );
+
+    const subscribeForEvent = ['topChange'];
+    if (textViewHandlers.onFocus != null) {
+        subscribeForEvent.push('topFocus');
+    }
+    if (textViewHandlers.onBlur != null) {
+        subscribeForEvent.push('topBlur');
+    }
+    if (textViewHandlers.onSelectionChange != null) {
+        subscribeForEvent.push('topSelectionChange');
+    }
+
+    return {
+        onChange: useEvent(
+            (event: any) => {
+                'worklet';
+
+                const { onFocus, onBlur, onChange, onSelectionChange } = textViewHandlers;
+
+                if (onFocus && event.eventName.endsWith('topFocus')) {
+                    onFocus(event, context);
+                    return;
+                }
+                if (onBlur && event.eventName.endsWith('topBlur')) {
+                    onBlur(event, context);
+                    return;
+                }
+                if (onChange && event.eventName.endsWith('topChange')) {
+                    onChange(event, context);
+                    return;
+                }
+                if (onSelectionChange && event.eventName.endsWith('topSelectionChange')) {
+                    onSelectionChange(event, context);
+                }
+            },
+            subscribeForEvent,
+            doDependenciesDiffer,
+        ),
+    };
+}

--- a/kit/inputs/src/useTextViewHandler.web.ts
+++ b/kit/inputs/src/useTextViewHandler.web.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import type {
+    NativeSyntheticEvent,
+    TextInputChangeEventData,
+    TextInputFocusEventData,
+    TextInputSelectionChangeEventData,
+} from 'react-native';
+
+export function useTextViewHandler<Context extends Record<string, unknown>>(
+    handlers:
+        | {
+              onFocus?: (evt: TextInputFocusEventData, ctx: Context) => void;
+              onBlur?: (evt: TextInputFocusEventData, ctx: Context) => void;
+              onChange?: (evt: TextInputChangeEventData, ctx: Context) => void;
+              onSelectionChange?: (evt: TextInputSelectionChangeEventData, ctx: Context) => void;
+          }
+        | ((evt: TextInputChangeEventData) => void),
+    _dependencies?: Array<unknown>,
+) {
+    return React.useMemo(() => {
+        if (typeof handlers === 'function') {
+            return {
+                onChange: (e: NativeSyntheticEvent<TextInputChangeEventData>) =>
+                    handlers(e.nativeEvent),
+            };
+        }
+
+        return Object.keys(handlers).reduce((acc, key) => {
+            acc[key] = (e: NativeSyntheticEvent<any>) => {
+                // @ts-ignore
+                handlers[key](e.nativeEvent);
+            };
+            return acc;
+        }, {} as any);
+    }, [handlers]);
+}


### PR DESCRIPTION
So I tried to fix a bug, when you tap a clear button and an input mess up with it's internal state.
It happened because `onBlur` actually can fire with a delay. Though an easy fix was to just put `rAF` around `clear` call in the button, but I already wanted to move more logic to UI thread, moving `onBlur` to UI thread, it fires much faster than before, basically removing the bug I mentioned.

It worth to mention that it's actually not a complete solution (for example it still updates text via a ref, though we can apply mask directly from UI thread), I would rather call it a first step, before we do sth truly cool, and we have to discuss it internally with @SAnatoliiS 