### PR TITLE
Use `allSettled` polyfill

### DIFF
--- a/casts/bars/src/UILargeTitleHeader/RefreshControl.tsx
+++ b/casts/bars/src/UILargeTitleHeader/RefreshControl.tsx
@@ -18,6 +18,29 @@ import { NON_UI_RUBBER_BAND_EFFECT_DISTANCE } from './useRubberBandEffectDistanc
 
 export type OnRefresh = () => Promise<void>;
 
+const allSettled =
+    Promise.allSettled ||
+    /**
+     * Use a polyfill
+     * (from https://github.com/amrayn/allsettled-polyfill/blob/master/index.js)
+     * in case `allSettled` is not present in runtime
+     * (like in Hermes)
+     */
+    ((promises: Promise<any>[]) =>
+        Promise.all(
+            promises.map(p =>
+                p
+                    .then(value => ({
+                        status: 'fulfilled',
+                        value,
+                    }))
+                    .catch(reason => ({
+                        status: 'rejected',
+                        reason,
+                    })),
+            ),
+        ));
+
 export function RefreshControl({
     onRefresh,
     background,
@@ -52,7 +75,7 @@ export function RefreshControl({
         await new Promise(res => requestAnimationFrame(res));
 
         try {
-            await Promise.allSettled([
+            await allSettled([
                 onRefresh(),
                 // An artificial timeout is needed
                 // in case the refresh is super fast


### PR DESCRIPTION
So not all runtimes have a polyfill yet (Hermes 👀) and babel doesn't polyfill it automatically, so I did it myself