### PR TITLE
Add on change callback to modal navigator screen

### DIFF
--- a/casts/modalNavigator/src/ModalNavigator/ModalRouter.ts
+++ b/casts/modalNavigator/src/ModalNavigator/ModalRouter.ts
@@ -10,7 +10,6 @@ import {
     PartialState,
 } from '@react-navigation/native';
 import sortBy from 'lodash/sortBy';
-import type { UIModalSheetProps } from '@tonlabs/uikit.popups';
 
 type ModalScreenProps = {
     name: string;
@@ -93,10 +92,10 @@ export const ModalActions = {
     },
 };
 
-export type ModalActionHelpers = {
-    show(name: string, params?: Record<string, unknown>): ModalActionType;
-    hide(name?: string): ModalActionType;
-    hideAll(): ModalActionType;
+export type ModalActionHelpers = Record<string, () => void> & {
+    show(name: string, params?: Record<string, unknown>): void;
+    hide(name?: string): void;
+    hideAll(): void;
 };
 
 type ModalRouterOptions = {
@@ -111,7 +110,6 @@ export type ModalNavigationRoute<
     state?: NavigationState | PartialState<NavigationState>;
     order: number;
     visible: boolean;
-    onClose?: UIModalSheetProps['onClose'];
 };
 
 export type ModalNavigationState<ParamList extends ParamListBase = ParamListBase> = {

--- a/casts/modalNavigator/src/ModalNavigator/createModalNavigator.tsx
+++ b/casts/modalNavigator/src/ModalNavigator/createModalNavigator.tsx
@@ -1,29 +1,32 @@
 import * as React from 'react';
 import { Keyboard } from 'react-native';
-import type { NavigationProp, RouteProp } from '@react-navigation/core';
+import type { NavigationProp } from '@react-navigation/core';
 import {
     NavigationHelpersContext,
     useNavigationBuilder,
     createNavigatorFactory,
 } from '@react-navigation/native';
-import type { Descriptor, ParamListBase, EventMapBase } from '@react-navigation/native';
+import type { ParamListBase, EventMapBase } from '@react-navigation/native';
 
 import { PortalManager } from '@tonlabs/uikit.layout';
 import { UIModalSheet } from '@tonlabs/uikit.popups';
 
 import { ModalRouter, ModalActions, ModalActionHelpers } from './ModalRouter';
-import type { ModalNavigationState, ModalNavigationRoute } from './ModalRouter';
+import type { ModalNavigationState } from './ModalRouter';
+import type {
+    ModalNavigatorScreenProps,
+    ModalNavigatorProps,
+    ModalRouterOptions,
+    ModalScreenOptions,
+} from './types';
 
 function ModalScreen<ParamList extends ParamListBase = ParamListBase>({
     route,
     descriptor,
     maxMobileWidth,
-}: {
-    route: ModalNavigationRoute<ParamList, keyof ParamList>;
-    descriptor: Descriptor<ParamListBase>;
-    maxMobileWidth: number;
-}) {
-    const { name, onClose } = route;
+}: ModalNavigatorScreenProps<ParamList>) {
+    const { name } = route;
+    const { onClose } = descriptor.options;
 
     const hide = React.useCallback(() => {
         Keyboard.dismiss();
@@ -43,16 +46,17 @@ function ModalScreen<ParamList extends ParamListBase = ParamListBase>({
     );
 }
 
-const ModalNavigator = ({
-    children,
-    maxMobileWidth,
-}: {
-    children: React.ReactNode;
-    maxMobileWidth: number;
-}) => {
-    const { state, navigation, descriptors } = useNavigationBuilder(ModalRouter, {
+const ModalNavigator = ({ children, maxMobileWidth, screenOptions }: ModalNavigatorProps) => {
+    const { state, navigation, descriptors } = useNavigationBuilder<
+        ModalNavigationState,
+        ModalRouterOptions,
+        ModalActionHelpers,
+        ModalScreenOptions,
+        NavigationProp<ParamListBase>
+    >(ModalRouter, {
         children,
         childrenForConfigs: children,
+        screenOptions,
     });
 
     return (
@@ -77,23 +81,6 @@ const ModalNavigator = ({
             </NavigationHelpersContext.Provider>
         </PortalManager>
     );
-};
-
-type ModalScreenOptions = {
-    defaultProps: Record<string, unknown>;
-};
-
-export type ModalNavigationProp<
-    ParamList extends ParamListBase,
-    RouteName extends keyof ParamList = string,
-> = NavigationProp<ParamList, RouteName, ModalNavigationState<ParamList>, /* TODO */ any> &
-    ModalActionHelpers;
-export type ModalScreenProps<
-    ParamList extends ParamListBase,
-    RouteName extends keyof ParamList = string,
-> = {
-    navigation: ModalNavigationProp<ParamList, RouteName>;
-    route: RouteProp<ParamList, RouteName>;
 };
 
 export const createModalNavigator = createNavigatorFactory<

--- a/casts/modalNavigator/src/ModalNavigator/index.ts
+++ b/casts/modalNavigator/src/ModalNavigator/index.ts
@@ -1,3 +1,3 @@
 export { createModalNavigator } from './createModalNavigator';
-export type { ModalNavigationProp, ModalScreenProps } from './createModalNavigator';
+export type { ModalNavigationProp, ModalScreenProps, ModalScreenOptions } from './types';
 export { ModalActions } from './ModalRouter';

--- a/casts/modalNavigator/src/ModalNavigator/types.ts
+++ b/casts/modalNavigator/src/ModalNavigator/types.ts
@@ -1,0 +1,58 @@
+import type {
+    DefaultRouterOptions,
+    Descriptor,
+    EventMapBase,
+    NavigationProp,
+    ParamListBase,
+    RouteProp,
+} from '@react-navigation/native';
+
+import { UIModalSheetProps } from '@tonlabs/uikit.popups';
+
+import type { ModalActionHelpers, ModalNavigationRoute, ModalNavigationState } from './ModalRouter';
+
+export type ModalScreenOptions = {
+    /**
+     * Callback that is called when the user close the modal.
+     */
+    onClose?: UIModalSheetProps['onClose'];
+};
+export type ModalDescriptor = Descriptor<
+    Record<string, any>,
+    string,
+    ModalNavigationState,
+    ModalScreenOptions,
+    EventMapBase
+>;
+
+export type ModalNavigatorProps = {
+    children?: React.ReactNode;
+    maxMobileWidth: number;
+    screenOptions?: ModalScreenOptions;
+};
+
+export type ModalNavigatorScreenProps<ParamList extends ParamListBase = ParamListBase> = {
+    route: ModalNavigationRoute<ParamList, keyof ParamList>;
+    descriptor: ModalDescriptor;
+    maxMobileWidth: number;
+};
+
+type ModalRouterCustomOptions = {
+    childrenForConfigs: React.ReactNode;
+};
+export type ModalRouterOptions<ParamList extends ParamListBase = ParamListBase> =
+    DefaultRouterOptions<Extract<keyof ParamList, string>> & ModalRouterCustomOptions;
+
+export type ModalNavigationProp<
+    ParamList extends ParamListBase,
+    RouteName extends keyof ParamList = string,
+> = NavigationProp<ParamList, RouteName, ModalNavigationState<ParamList>, ModalScreenOptions> &
+    ModalActionHelpers;
+
+export type ModalScreenProps<
+    ParamList extends ParamListBase,
+    RouteName extends keyof ParamList = string,
+> = {
+    navigation: ModalNavigationProp<ParamList, RouteName>;
+    route: RouteProp<ParamList, RouteName>;
+};

--- a/casts/modalNavigator/src/ModalNavigator/types.ts
+++ b/casts/modalNavigator/src/ModalNavigator/types.ts
@@ -1,7 +1,6 @@
 import type {
     DefaultRouterOptions,
     Descriptor,
-    EventMapBase,
     NavigationProp,
     ParamListBase,
     RouteProp,
@@ -17,12 +16,13 @@ export type ModalScreenOptions = {
      */
     onClose?: UIModalSheetProps['onClose'];
 };
-export type ModalDescriptor = Descriptor<
-    Record<string, any>,
-    string,
+export type ModalDescriptor<ParamList extends ParamListBase = ParamListBase> = Descriptor<
+    ParamList,
+    keyof ParamList,
     ModalNavigationState,
     ModalScreenOptions,
-    EventMapBase
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    {}
 >;
 
 export type ModalNavigatorProps = {
@@ -33,7 +33,7 @@ export type ModalNavigatorProps = {
 
 export type ModalNavigatorScreenProps<ParamList extends ParamListBase = ParamListBase> = {
     route: ModalNavigationRoute<ParamList, keyof ParamList>;
-    descriptor: ModalDescriptor;
+    descriptor: ModalDescriptor<ParamList>;
     maxMobileWidth: number;
 };
 

--- a/casts/modalNavigator/src/ModalNavigator/types.ts
+++ b/casts/modalNavigator/src/ModalNavigator/types.ts
@@ -7,7 +7,7 @@ import type {
     RouteProp,
 } from '@react-navigation/native';
 
-import { UIModalSheetProps } from '@tonlabs/uikit.popups';
+import type { UIModalSheetProps } from '@tonlabs/uikit.popups';
 
 import type { ModalActionHelpers, ModalNavigationRoute, ModalNavigationState } from './ModalRouter';
 


### PR DESCRIPTION
Now you can use `onClose` callback on ModalNavigation sheet close.
First, you need to create ModalNavigationOptions:

```ts
export const ScreenNameModalNavigationOptions: () => ModalScreenOptions = () => ({
    onClose: () => {
        // Your action
    },
});
```
And provide it into the `options` in the `Screen` component
```ts
<ModalNavigator.Screen
    name={ModalPath.ScreenName}
    component={ScreenNameModal}
    options={ScreenNameModalNavigationOptions} // <- here
/>
```